### PR TITLE
fix(booking): comprehensive timezone, slot algorithm, and availability fixes

### DIFF
--- a/backend/lib/database/repositories/appointment_repository.dart
+++ b/backend/lib/database/repositories/appointment_repository.dart
@@ -216,9 +216,19 @@ class AppointmentRepository extends BaseRepository {
     );
 
     if (conflicts.isNotEmpty) {
+      // Format times in a readable way (UTC)
+      final formattedTimes = conflicts.map((d) {
+        final hour = d.hour % 12 == 0 ? 12 : d.hour % 12;
+        final minute = d.minute.toString().padLeft(2, '0');
+        final period = d.hour < 12 ? 'AM' : 'PM';
+        final months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return '${months[d.month - 1]} ${d.day} at $hour:$minute $period UTC';
+      }).join(', ');
+
       throw SlotConflictException(
         'The following time slots are no longer available: '
-        '${conflicts.map((d) => d.toIso8601String()).join(', ')}. '
+        '$formattedTimes. '
         'Please select different times.',
       );
     }

--- a/backend/lib/database/repositories/appointment_repository.dart
+++ b/backend/lib/database/repositories/appointment_repository.dart
@@ -27,6 +27,12 @@ class SlotConflictException implements Exception {
 ///
 /// Uses JsonQueryBuilder for type-safe queries, eliminating SQL injection risks.
 class AppointmentRepository extends BaseRepository {
+  /// Month abbreviations for date formatting
+  static const _months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
   /// Create an appointment repository with the given executor
   AppointmentRepository(super._executor);
 
@@ -221,9 +227,7 @@ class AppointmentRepository extends BaseRepository {
         final hour = d.hour % 12 == 0 ? 12 : d.hour % 12;
         final minute = d.minute.toString().padLeft(2, '0');
         final period = d.hour < 12 ? 'AM' : 'PM';
-        final months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-        return '${months[d.month - 1]} ${d.day} at $hour:$minute $period UTC';
+        return '${_months[d.month - 1]} ${d.day} at $hour:$minute $period UTC';
       }).join(', ');
 
       throw SlotConflictException(

--- a/backend/lib/database/repositories/consultant_explore_repository.dart
+++ b/backend/lib/database/repositories/consultant_explore_repository.dart
@@ -472,7 +472,7 @@ class ConsultantExploreRepository extends BaseRepository {
       'learningOutcomes',
       'createdAt',
     ]).where({'consultantProfileId': consultantId}).orderBy(
-            {'price': 'asc'}).build();
+            {'durationInHours': 'asc'}).build();
 
     final result = await executeQueryAsMaps(query);
 
@@ -523,7 +523,7 @@ class ConsultantExploreRepository extends BaseRepository {
       'learningOutcomes',
       'createdAt',
     ]).where({'consultantProfileId': consultantId}).orderBy(
-            {'price': 'asc'}).build();
+            {'sessionDurationInHours': 'asc'}).build();
 
     final result = await executeQueryAsMaps(query);
 

--- a/backend/lib/database/repositories/slot_repository.dart
+++ b/backend/lib/database/repositories/slot_repository.dart
@@ -85,9 +85,16 @@ class SlotRepository extends BaseRepository {
     required DateTime startDate,
     required DateTime endDate,
   }) async {
-    // Get all booked slots for this consultant's appointments.
+    // Get all booked slots for this consultant's ACTIVE appointments.
     // Path: SlotOfAppointment -> Appointment -> (Consultation|Subscription) -> Plan
-    // Use AND to combine both date range conditions on startsAt
+    // Only include appointments with active statuses (exclude CANCELLED, REJECTED, EXPIRED)
+    const activeStatuses = [
+      'PENDING',
+      'APPROVED',
+      'APPROVED_PENDING_PAYMENT',
+      'SCHEDULED',
+    ];
+
     final query = JsonQueryBuilder()
         .model('SlotOfAppointment')
         .action(QueryAction.findMany)
@@ -99,13 +106,21 @@ class SlotRepository extends BaseRepository {
         {'startsAt': FilterOperators.lt(endDate.toIso8601String())},
       ],
       'OR': [
+        // Consultation appointments: filter by consultant AND active status
         FilterOperators.relationPath(
-          'appointment.consultation.consultationPlan',
-          {'consultantProfileId': consultantProfileId},
+          'appointment.consultation',
+          {
+            'consultationPlan': {'consultantProfileId': consultantProfileId},
+            'requestStatus': FilterOperators.in_(activeStatuses),
+          },
         ),
+        // Subscription appointments: filter by consultant AND active status
         FilterOperators.relationPath(
-          'appointment.subscription.subscriptionPlan',
-          {'consultantProfileId': consultantProfileId},
+          'appointment.subscription',
+          {
+            'subscriptionPlan': {'consultantProfileId': consultantProfileId},
+            'requestStatus': FilterOperators.in_(activeStatuses),
+          },
         ),
       ],
     }).build();
@@ -151,7 +166,7 @@ class SlotRepository extends BaseRepository {
 
     // Generate slots at 30-minute increments within each merged window
     final expandedSlots = <Map<String, dynamic>>[];
-    final now = DateTime.now();
+    final now = DateTime.now().toUtc(); // Use UTC for consistent timezone handling
     final slotDuration = Duration(minutes: durationMinutes);
     const slotIncrement = Duration(minutes: 30);
 
@@ -214,17 +229,84 @@ class SlotRepository extends BaseRepository {
     // Expand weekly pattern into specific date slots with plan duration
     final expandedSlots = <Map<String, dynamic>>[];
     var currentDate = startDate;
-    final now = DateTime.now();
+    final now = DateTime.now().toUtc(); // Use UTC for consistent timezone handling
     final slotDuration = Duration(minutes: durationMinutes);
     const slotIncrement = Duration(minutes: 30); // 30-min increments
 
     while (currentDate.isBefore(endDate)) {
       final dayOfWeek = _getDayOfWeekString(currentDate.weekday);
+      final previousDayOfWeek = _getDayOfWeekString(
+        currentDate.weekday == 1 ? 7 : currentDate.weekday - 1,
+      );
 
-      // Filter windows for this day
+      // Filter windows that START on this day
       final dayWindows = weeklySlots
           .where((s) => s['dayOfWeekForStartsAt'] == dayOfWeek)
           .toList();
+
+      // Also get cross-day windows that END on this day (started on previous day)
+      // This handles overnight availability like Mon 22:00 - Tue 02:00
+      // when the query range starts on Tuesday
+      final crossDayWindows = weeklySlots
+          .where((s) =>
+              s['dayOfWeekForEndsAt'] == dayOfWeek &&
+              s['dayOfWeekForStartsAt'] == previousDayOfWeek)
+          .toList();
+
+      // Process cross-day windows: only the post-midnight portion
+      for (final crossDaySlot in crossDayWindows) {
+        final availEnd = crossDaySlot['availabilityEndsAt'];
+        DateTime windowEnd;
+        if (availEnd is DateTime) {
+          windowEnd = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            availEnd.hour,
+            availEnd.minute,
+          );
+        } else {
+          final parsed = DateTime.parse(availEnd.toString());
+          windowEnd = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            parsed.hour,
+            parsed.minute,
+          );
+        }
+
+        // Generate slots from midnight to windowEnd (the post-midnight portion)
+        final windowStart = DateTime(
+          currentDate.year,
+          currentDate.month,
+          currentDate.day,
+          0, // Start at midnight
+          0,
+        );
+
+        // Only generate if end is after midnight
+        if (windowEnd.isAfter(windowStart)) {
+          var slotStart = windowStart;
+          while (slotStart.add(slotDuration).isBefore(windowEnd) ||
+              slotStart.add(slotDuration).isAtSameMomentAs(windowEnd)) {
+            final slotEnd = slotStart.add(slotDuration);
+            final isPast = slotStart.isBefore(now);
+            final isBooked = _isSlotBooked(slotStart, slotEnd, bookedSlots);
+
+            expandedSlots.add({
+              'id': '${crossDaySlot['id']}_crossday_${slotStart.toIso8601String()}',
+              'startsAt': slotStart,
+              'endsAt': slotEnd,
+              'isBooked': isBooked,
+              'isTentative': false,
+              'isPast': isPast,
+            });
+
+            slotStart = slotStart.add(slotIncrement);
+          }
+        }
+      }
 
       // Merge consecutive windows to allow longer duration slots
       final mergedWindows = _mergeConsecutiveWindows(dayWindows, currentDate);
@@ -275,6 +357,13 @@ class SlotRepository extends BaseRepository {
           );
         }
 
+        // Fix cross-midnight windows: if end time is before or equal to start time,
+        // it means the window crosses midnight and end is on the next day
+        if (windowEnd.isBefore(windowStart) ||
+            windowEnd.isAtSameMomentAs(windowStart)) {
+          windowEnd = windowEnd.add(const Duration(days: 1));
+        }
+
         // Generate slots at 30-minute increments within the merged window
         var slotStart = windowStart;
         while (slotStart.add(slotDuration).isBefore(windowEnd) ||
@@ -306,13 +395,20 @@ class SlotRepository extends BaseRepository {
     return expandedSlots;
   }
 
-  /// Check if a slot overlaps with any booked slot
+  /// Check if a slot overlaps with any confirmed (non-tentative) booked slot
+  ///
+  /// Tentative slots are excluded because they haven't been confirmed yet
+  /// and shouldn't block other users from booking the same time.
   bool _isSlotBooked(
     DateTime slotStart,
     DateTime slotEnd,
     List<Map<String, dynamic>> bookedSlots,
   ) {
     for (final bookedSlot in bookedSlots) {
+      // Skip tentative slots - they don't block availability
+      // Only confirmed appointments should prevent new bookings
+      if (bookedSlot['isTentative'] == true) continue;
+
       final bookedStart = _parseDateTime(bookedSlot['startsAt']);
       final bookedEnd = _parseDateTime(bookedSlot['endsAt']);
 

--- a/backend/lib/database/repositories/slot_repository.dart
+++ b/backend/lib/database/repositories/slot_repository.dart
@@ -15,15 +15,18 @@ class SlotRepository extends BaseRepository {
   /// Get consultant's available time slots for a date range
   ///
   /// Returns a list of available slots grouped by date.
-  /// Excludes slots that are already booked or tentative.
+  /// Each slot duration is based on the plan duration.
+  /// Slots are marked with isBooked/isPast flags instead of being filtered out.
   ///
   /// [consultantProfileId] - The consultant profile ID
   /// [startDate] - Start of the date range (inclusive)
   /// [endDate] - End of the date range (exclusive)
+  /// [durationMinutes] - Duration of each slot in minutes (default: 60)
   Future<List<Map<String, dynamic>>> getAvailability({
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
+    int durationMinutes = 60,
   }) async {
     // Get consultant's schedule type and availability slots
     final consultantData = await _getConsultantSchedule(consultantProfileId);
@@ -47,6 +50,7 @@ class SlotRepository extends BaseRepository {
         startDate: startDate,
         endDate: endDate,
         bookedSlots: bookedSlots,
+        durationMinutes: durationMinutes,
       );
     } else {
       // WEEKLY is the default
@@ -55,6 +59,7 @@ class SlotRepository extends BaseRepository {
         startDate: startDate,
         endDate: endDate,
         bookedSlots: bookedSlots,
+        durationMinutes: durationMinutes,
       );
     }
   }
@@ -109,11 +114,15 @@ class SlotRepository extends BaseRepository {
   }
 
   /// Get custom one-time availability slots using ORM
+  ///
+  /// Generates slots at 30-minute increments with the specified duration.
+  /// Returns all slots with isBooked/isPast flags for UI display.
   Future<List<Map<String, dynamic>>> _getCustomAvailability({
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
     required List<Map<String, dynamic>> bookedSlots,
+    required int durationMinutes,
   }) async {
     // Get custom availability slots within the date range using ORM
     final query = JsonQueryBuilder()
@@ -137,25 +146,56 @@ class SlotRepository extends BaseRepository {
 
     final results = await executeQueryAsMaps(query);
 
-    // Map to expected format
-    final slots = results
-        .map((r) => {
-              'id': r['id'],
-              'startsAt': r['availabilityStartsAt'],
-              'endsAt': r['availabilityEndsAt'],
-            },)
-        .toList();
+    // Merge consecutive custom windows to allow longer duration slots
+    final mergedResults = _mergeConsecutiveCustomWindows(results);
 
-    // Filter out booked slots
-    return _filterBookedSlots(slots, bookedSlots);
+    // Generate slots at 30-minute increments within each merged window
+    final expandedSlots = <Map<String, dynamic>>[];
+    final now = DateTime.now();
+    final slotDuration = Duration(minutes: durationMinutes);
+    const slotIncrement = Duration(minutes: 30);
+
+    for (final customSlot in mergedResults) {
+      final windowStart = _parseDateTime(customSlot['availabilityStartsAt']);
+      final windowEnd = _parseDateTime(customSlot['availabilityEndsAt']);
+
+      var slotStart = windowStart;
+      while (slotStart.add(slotDuration).isBefore(windowEnd) ||
+             slotStart.add(slotDuration).isAtSameMomentAs(windowEnd)) {
+        final slotEnd = slotStart.add(slotDuration);
+
+        // Check if slot is in the past
+        final isPast = slotStart.isBefore(now);
+
+        // Check if slot overlaps with any booked slot
+        final isBooked = _isSlotBooked(slotStart, slotEnd, bookedSlots);
+
+        expandedSlots.add({
+          'id': '${customSlot['id']}_${slotStart.toIso8601String()}',
+          'startsAt': slotStart,
+          'endsAt': slotEnd,
+          'isBooked': isBooked,
+          'isTentative': false,
+          'isPast': isPast,
+        });
+
+        slotStart = slotStart.add(slotIncrement);
+      }
+    }
+
+    return expandedSlots;
   }
 
   /// Expand weekly recurring availability into specific slots for a date range
+  ///
+  /// Generates slots at 30-minute increments with the specified duration.
+  /// Returns all slots with isBooked/isPast flags for UI display.
   Future<List<Map<String, dynamic>>> _getWeeklyAvailability({
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
     required List<Map<String, dynamic>> bookedSlots,
+    required int durationMinutes,
   }) async {
     // Get weekly availability pattern using ORM
     final query = JsonQueryBuilder()
@@ -171,78 +211,117 @@ class SlotRepository extends BaseRepository {
       return [];
     }
 
-    // Expand weekly pattern into specific date slots
+    // Expand weekly pattern into specific date slots with plan duration
     final expandedSlots = <Map<String, dynamic>>[];
     var currentDate = startDate;
+    final now = DateTime.now();
+    final slotDuration = Duration(minutes: durationMinutes);
+    const slotIncrement = Duration(minutes: 30); // 30-min increments
 
     while (currentDate.isBefore(endDate)) {
       final dayOfWeek = _getDayOfWeekString(currentDate.weekday);
 
-      for (final weeklySlot in weeklySlots) {
-        if (weeklySlot['dayOfWeekForStartsAt'] == dayOfWeek) {
-          // Parse the time from the availability slot
-          final availStart = weeklySlot['availabilityStartsAt'];
-          final availEnd = weeklySlot['availabilityEndsAt'];
+      // Filter windows for this day
+      final dayWindows = weeklySlots
+          .where((s) => s['dayOfWeekForStartsAt'] == dayOfWeek)
+          .toList();
 
-          DateTime startTime;
-          DateTime endTime;
+      // Merge consecutive windows to allow longer duration slots
+      final mergedWindows = _mergeConsecutiveWindows(dayWindows, currentDate);
 
-          if (availStart is DateTime) {
-            startTime = DateTime(
-              currentDate.year,
-              currentDate.month,
-              currentDate.day,
-              availStart.hour,
-              availStart.minute,
-            );
-          } else {
-            // Parse from string if needed
-            final parsed = DateTime.parse(availStart.toString());
-            startTime = DateTime(
-              currentDate.year,
-              currentDate.month,
-              currentDate.day,
-              parsed.hour,
-              parsed.minute,
-            );
-          }
+      for (final weeklySlot in mergedWindows) {
+        // Parse the availability window times
+        final availStart = weeklySlot['availabilityStartsAt'];
+        final availEnd = weeklySlot['availabilityEndsAt'];
 
-          if (availEnd is DateTime) {
-            endTime = DateTime(
-              currentDate.year,
-              currentDate.month,
-              currentDate.day,
-              availEnd.hour,
-              availEnd.minute,
-            );
-          } else {
-            final parsed = DateTime.parse(availEnd.toString());
-            endTime = DateTime(
-              currentDate.year,
-              currentDate.month,
-              currentDate.day,
-              parsed.hour,
-              parsed.minute,
-            );
-          }
+        DateTime windowStart;
+        DateTime windowEnd;
 
-          // Only add future slots
-          if (startTime.isAfter(DateTime.now())) {
-            final dateStr = currentDate.toIso8601String().split('T')[0];
-            expandedSlots.add({
-              'id': '${weeklySlot['id']}_$dateStr',
-              'startsAt': startTime,
-              'endsAt': endTime,
-            });
-          }
+        if (availStart is DateTime) {
+          windowStart = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            availStart.hour,
+            availStart.minute,
+          );
+        } else {
+          final parsed = DateTime.parse(availStart.toString());
+          windowStart = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            parsed.hour,
+            parsed.minute,
+          );
+        }
+
+        if (availEnd is DateTime) {
+          windowEnd = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            availEnd.hour,
+            availEnd.minute,
+          );
+        } else {
+          final parsed = DateTime.parse(availEnd.toString());
+          windowEnd = DateTime(
+            currentDate.year,
+            currentDate.month,
+            currentDate.day,
+            parsed.hour,
+            parsed.minute,
+          );
+        }
+
+        // Generate slots at 30-minute increments within the merged window
+        var slotStart = windowStart;
+        while (slotStart.add(slotDuration).isBefore(windowEnd) ||
+               slotStart.add(slotDuration).isAtSameMomentAs(windowEnd)) {
+          final slotEnd = slotStart.add(slotDuration);
+
+          // Check if slot is in the past
+          final isPast = slotStart.isBefore(now);
+
+          // Check if slot overlaps with any booked slot
+          final isBooked = _isSlotBooked(slotStart, slotEnd, bookedSlots);
+
+          expandedSlots.add({
+            'id': '${weeklySlot['id']}_${slotStart.toIso8601String()}',
+            'startsAt': slotStart,
+            'endsAt': slotEnd,
+            'isBooked': isBooked,
+            'isTentative': false,
+            'isPast': isPast,
+          });
+
+          slotStart = slotStart.add(slotIncrement);
         }
       }
 
       currentDate = currentDate.add(const Duration(days: 1));
     }
 
-    // Filter out booked slots
-    return _filterBookedSlots(expandedSlots, bookedSlots);
+    return expandedSlots;
+  }
+
+  /// Check if a slot overlaps with any booked slot
+  bool _isSlotBooked(
+    DateTime slotStart,
+    DateTime slotEnd,
+    List<Map<String, dynamic>> bookedSlots,
+  ) {
+    for (final bookedSlot in bookedSlots) {
+      final bookedStart = _parseDateTime(bookedSlot['startsAt']);
+      final bookedEnd = _parseDateTime(bookedSlot['endsAt']);
+
+      // Slots overlap if one starts before the other ends
+      if (slotStart.isBefore(bookedEnd) && slotEnd.isAfter(bookedStart)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /// Filter out slots that overlap with booked slots
@@ -272,6 +351,110 @@ class SlotRepository extends BaseRepository {
   DateTime _parseDateTime(dynamic value) {
     if (value is DateTime) return value;
     return DateTime.parse(value.toString());
+  }
+
+  /// Parse time from availability window and apply to a specific date
+  DateTime _parseTimeForDate(dynamic value, DateTime date) {
+    DateTime parsed;
+    if (value is DateTime) {
+      parsed = value;
+    } else {
+      parsed = DateTime.parse(value.toString());
+    }
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      parsed.hour,
+      parsed.minute,
+    );
+  }
+
+  /// Merge consecutive availability windows into continuous blocks
+  ///
+  /// This allows longer duration plans (2hr, 4hr) to span multiple
+  /// individual 1-hour availability windows stored in the database.
+  List<Map<String, dynamic>> _mergeConsecutiveWindows(
+    List<Map<String, dynamic>> windows,
+    DateTime currentDate,
+  ) {
+    if (windows.isEmpty) return [];
+
+    // Sort windows by start time
+    final sortedWindows = List<Map<String, dynamic>>.from(windows);
+    sortedWindows.sort((a, b) {
+      final aStart = _parseTimeForDate(a['availabilityStartsAt'], currentDate);
+      final bStart = _parseTimeForDate(b['availabilityStartsAt'], currentDate);
+      return aStart.compareTo(bStart);
+    });
+
+    final merged = <Map<String, dynamic>>[];
+    var currentWindow = Map<String, dynamic>.from(sortedWindows.first);
+
+    for (var i = 1; i < sortedWindows.length; i++) {
+      final nextWindow = sortedWindows[i];
+      final currentEnd =
+          _parseTimeForDate(currentWindow['availabilityEndsAt'], currentDate);
+      final nextStart =
+          _parseTimeForDate(nextWindow['availabilityStartsAt'], currentDate);
+
+      // If consecutive (ends at same time as next starts or overlaps), merge
+      if (currentEnd.isAtSameMomentAs(nextStart) ||
+          currentEnd.isAfter(nextStart)) {
+        // Extend current window's end time to the later of the two
+        final nextEnd =
+            _parseTimeForDate(nextWindow['availabilityEndsAt'], currentDate);
+        if (nextEnd.isAfter(currentEnd)) {
+          currentWindow['availabilityEndsAt'] =
+              nextWindow['availabilityEndsAt'];
+        }
+      } else {
+        // Gap between windows, save current and start new
+        merged.add(currentWindow);
+        currentWindow = Map<String, dynamic>.from(nextWindow);
+      }
+    }
+    merged.add(currentWindow);
+
+    return merged;
+  }
+
+  /// Merge consecutive custom availability windows into continuous blocks
+  ///
+  /// Similar to _mergeConsecutiveWindows but for custom slots that have
+  /// full DateTime values (not just time-of-day).
+  List<Map<String, dynamic>> _mergeConsecutiveCustomWindows(
+    List<Map<String, dynamic>> windows,
+  ) {
+    if (windows.isEmpty) return [];
+
+    // Windows are already sorted by availabilityStartsAt from the query
+    final merged = <Map<String, dynamic>>[];
+    var currentWindow = Map<String, dynamic>.from(windows.first);
+
+    for (var i = 1; i < windows.length; i++) {
+      final nextWindow = windows[i];
+      final currentEnd = _parseDateTime(currentWindow['availabilityEndsAt']);
+      final nextStart = _parseDateTime(nextWindow['availabilityStartsAt']);
+
+      // If consecutive (ends at same time as next starts or overlaps), merge
+      if (currentEnd.isAtSameMomentAs(nextStart) ||
+          currentEnd.isAfter(nextStart)) {
+        // Extend current window's end time to the later of the two
+        final nextEnd = _parseDateTime(nextWindow['availabilityEndsAt']);
+        if (nextEnd.isAfter(currentEnd)) {
+          currentWindow['availabilityEndsAt'] =
+              nextWindow['availabilityEndsAt'];
+        }
+      } else {
+        // Gap between windows, save current and start new
+        merged.add(currentWindow);
+        currentWindow = Map<String, dynamic>.from(nextWindow);
+      }
+    }
+    merged.add(currentWindow);
+
+    return merged;
   }
 
   /// Convert weekday number to enum string

--- a/backend/lib/database/repositories/slot_repository.dart
+++ b/backend/lib/database/repositories/slot_repository.dart
@@ -255,26 +255,10 @@ class SlotRepository extends BaseRepository {
 
       // Process cross-day windows: only the post-midnight portion
       for (final crossDaySlot in crossDayWindows) {
-        final availEnd = crossDaySlot['availabilityEndsAt'];
-        DateTime windowEnd;
-        if (availEnd is DateTime) {
-          windowEnd = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            availEnd.hour,
-            availEnd.minute,
-          );
-        } else {
-          final parsed = DateTime.parse(availEnd.toString());
-          windowEnd = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            parsed.hour,
-            parsed.minute,
-          );
-        }
+        final windowEnd = _parseTimeForDate(
+          crossDaySlot['availabilityEndsAt'],
+          currentDate,
+        );
 
         // Generate slots from midnight to windowEnd (the post-midnight portion)
         final windowStart = DateTime(
@@ -312,50 +296,15 @@ class SlotRepository extends BaseRepository {
       final mergedWindows = _mergeConsecutiveWindows(dayWindows, currentDate);
 
       for (final weeklySlot in mergedWindows) {
-        // Parse the availability window times
-        final availStart = weeklySlot['availabilityStartsAt'];
-        final availEnd = weeklySlot['availabilityEndsAt'];
-
-        DateTime windowStart;
-        DateTime windowEnd;
-
-        if (availStart is DateTime) {
-          windowStart = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            availStart.hour,
-            availStart.minute,
-          );
-        } else {
-          final parsed = DateTime.parse(availStart.toString());
-          windowStart = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            parsed.hour,
-            parsed.minute,
-          );
-        }
-
-        if (availEnd is DateTime) {
-          windowEnd = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            availEnd.hour,
-            availEnd.minute,
-          );
-        } else {
-          final parsed = DateTime.parse(availEnd.toString());
-          windowEnd = DateTime(
-            currentDate.year,
-            currentDate.month,
-            currentDate.day,
-            parsed.hour,
-            parsed.minute,
-          );
-        }
+        // Parse the availability window times using helper
+        var windowStart = _parseTimeForDate(
+          weeklySlot['availabilityStartsAt'],
+          currentDate,
+        );
+        var windowEnd = _parseTimeForDate(
+          weeklySlot['availabilityEndsAt'],
+          currentDate,
+        );
 
         // Fix cross-midnight windows: if end time is before or equal to start time,
         // it means the window crosses midnight and end is on the next day
@@ -418,30 +367,6 @@ class SlotRepository extends BaseRepository {
       }
     }
     return false;
-  }
-
-  /// Filter out slots that overlap with booked slots
-  List<Map<String, dynamic>> _filterBookedSlots(
-    List<Map<String, dynamic>> availableSlots,
-    List<Map<String, dynamic>> bookedSlots,
-  ) {
-    return availableSlots.where((availSlot) {
-      final availStart = _parseDateTime(availSlot['startsAt']);
-      final availEnd = _parseDateTime(availSlot['endsAt']);
-
-      // Check if this slot overlaps with any booked slot
-      for (final bookedSlot in bookedSlots) {
-        final bookedStart = _parseDateTime(bookedSlot['startsAt']);
-        final bookedEnd = _parseDateTime(bookedSlot['endsAt']);
-
-        // Check for overlap: slots overlap if one starts before the other ends
-        if (availStart.isBefore(bookedEnd) && availEnd.isAfter(bookedStart)) {
-          return false; // Slot is booked, filter it out
-        }
-      }
-
-      return true; // Slot is available
-    }).toList();
   }
 
   DateTime _parseDateTime(dynamic value) {

--- a/backend/routes/api/consultants/[id]/availability.dart
+++ b/backend/routes/api/consultants/[id]/availability.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
 final logger = AppLogger('ConsultantAvailabilityRoute');
 
@@ -13,6 +14,8 @@ final logger = AppLogger('ConsultantAvailabilityRoute');
 /// Query Parameters:
 /// - startDate: Start of the date range (ISO8601, required)
 /// - endDate: End of the date range (ISO8601, required)
+/// - planId: The plan ID to determine slot duration (optional)
+/// - planType: 'consultation' or 'subscription' (optional, defaults to 'consultation')
 ///
 /// Response:
 /// ```json
@@ -26,7 +29,8 @@ final logger = AppLogger('ConsultantAvailabilityRoute');
 ///           "startsAt": "2024-01-15T09:00:00Z",
 ///           "endsAt": "2024-01-15T10:00:00Z",
 ///           "isBooked": false,
-///           "isTentative": false
+///           "isTentative": false,
+///           "isPast": false
 ///         }
 ///       ]
 ///     }
@@ -103,11 +107,29 @@ Future<Response> onRequest(RequestContext context, String id) async {
     // The route receives consultant profile ID directly
     final consultantProfileId = id;
 
-    // Fetch availability
+    // Parse optional planId and planType to determine slot duration
+    final planId = params['planId'];
+    final planType = params['planType'] ?? 'consultation';
+    var durationMinutes = 60; // Default 1 hour
+
+    if (planId != null) {
+      // Fetch the plan to get duration
+      final planDuration = await _getPlanDuration(
+        db.executor,
+        planId,
+        planType,
+      );
+      if (planDuration != null) {
+        durationMinutes = planDuration;
+      }
+    }
+
+    // Fetch availability with plan duration
     final slots = await db.slots.getAvailability(
       consultantProfileId: consultantProfileId,
       startDate: startDate,
       endDate: endDate,
+      durationMinutes: durationMinutes,
     );
 
     // Group slots by date
@@ -131,5 +153,47 @@ Future<Response> onRequest(RequestContext context, String id) async {
         'error': {'message': 'Failed to fetch availability'},
       },
     );
+  }
+}
+
+/// Fetch plan duration in minutes from the database
+///
+/// Returns the duration in minutes, or null if plan not found.
+/// For ConsultationPlan, uses `durationInHours`.
+/// For SubscriptionPlan, uses `sessionDurationInHours`.
+Future<int?> _getPlanDuration(
+  QueryExecutor executor,
+  String planId,
+  String planType,
+) async {
+  try {
+    final modelName = planType.toLowerCase() == 'subscription'
+        ? 'SubscriptionPlan'
+        : 'ConsultationPlan';
+
+    final durationField = planType.toLowerCase() == 'subscription'
+        ? 'sessionDurationInHours'
+        : 'durationInHours';
+
+    final query = JsonQueryBuilder()
+        .model(modelName)
+        .action(QueryAction.findUnique)
+        .selectFields([durationField])
+        .where({'id': planId})
+        .build();
+
+    final result = await executor.executeQueryAsSingleMap(query);
+    if (result == null) {
+      return null;
+    }
+
+    final durationHours = result[durationField];
+    if (durationHours == null) return null;
+
+    // Convert hours to minutes
+    return ((durationHours as num) * 60).round();
+  } catch (e) {
+    logger.warning('Failed to fetch plan duration: $e');
+    return null;
   }
 }

--- a/lib/app/shells/main_shell.dart
+++ b/lib/app/shells/main_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/widgets/timezone_indicator.dart';
 import '../providers/navigation_provider.dart';
 
 /// Main shell widget that wraps the app content with a bottom navigation bar.
@@ -21,36 +22,56 @@ class MainShell extends ConsumerWidget {
 
     return Scaffold(
       body: child,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: currentIndex,
-        onDestinationSelected: (index) {
-          // Update the provider state
-          ref.read(navigationIndexProvider.notifier).setIndex(index);
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Timezone indicator banner
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              border: Border(
+                top: BorderSide(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                  width: 0.5,
+                ),
+              ),
+            ),
+            child: const Center(child: TimezoneIndicator()),
+          ),
+          NavigationBar(
+            selectedIndex: currentIndex,
+            onDestinationSelected: (index) {
+              // Update the provider state
+              ref.read(navigationIndexProvider.notifier).setIndex(index);
 
-          // Navigate to the corresponding route
-          final tab = NavigationTab.fromIndex(index);
-          context.go(tab.path);
-        },
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.explore_outlined),
-            selectedIcon: Icon(Icons.explore),
-            label: 'Explore',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.dashboard_outlined),
-            selectedIcon: Icon(Icons.dashboard),
-            label: 'Dashboard',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.chat_bubble_outline),
-            selectedIcon: Icon(Icons.chat_bubble),
-            label: 'Messages',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline),
-            selectedIcon: Icon(Icons.person),
-            label: 'Profile',
+              // Navigate to the corresponding route
+              final tab = NavigationTab.fromIndex(index);
+              context.go(tab.path);
+            },
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.explore_outlined),
+                selectedIcon: Icon(Icons.explore),
+                label: 'Explore',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.dashboard_outlined),
+                selectedIcon: Icon(Icons.dashboard),
+                label: 'Dashboard',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.chat_bubble_outline),
+                selectedIcon: Icon(Icons.chat_bubble),
+                label: 'Messages',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.person_outline),
+                selectedIcon: Icon(Icons.person),
+                label: 'Profile',
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -29,51 +29,61 @@ abstract final class Formatters {
   );
 
   /// Format date as "Jan 15, 2024"
+  /// Converts to local timezone before formatting
   static String date(DateTime dateTime) {
-    return _dateFormat.format(dateTime);
+    return _dateFormat.format(dateTime.toLocal());
   }
 
   /// Format date and time as "Jan 15, 2024 • 3:00 PM"
+  /// Converts to local timezone before formatting
   static String dateTime(DateTime dateTime) {
-    return _dateTimeFormat.format(dateTime);
+    return _dateTimeFormat.format(dateTime.toLocal());
   }
 
   /// Format time as "3:00 PM"
+  /// Converts to local timezone before formatting
   static String time(DateTime dateTime) {
-    return _timeFormat.format(dateTime);
+    return _timeFormat.format(dateTime.toLocal());
   }
 
   /// Format as "Jan 15"
+  /// Converts to local timezone before formatting
   static String dayMonth(DateTime dateTime) {
-    return _dayMonthFormat.format(dateTime);
+    return _dayMonthFormat.format(dateTime.toLocal());
   }
 
   /// Format as "Monday, January 15, 2024"
+  /// Converts to local timezone before formatting
   static String fullDate(DateTime dateTime) {
-    return _fullDateFormat.format(dateTime);
+    return _fullDateFormat.format(dateTime.toLocal());
   }
 
   /// Format as "January 2024"
+  /// Converts to local timezone before formatting
   static String monthYear(DateTime dateTime) {
-    return _monthYearFormat.format(dateTime);
+    return _monthYearFormat.format(dateTime.toLocal());
   }
 
   /// Format as "15/1/24"
+  /// Converts to local timezone before formatting
   static String shortDate(DateTime dateTime) {
-    return _shortDateFormat.format(dateTime);
+    return _shortDateFormat.format(dateTime.toLocal());
   }
 
   /// Format as relative time "2 hours ago", "just now", etc.
+  /// Converts to local timezone before calculating relative time
   static String relative(DateTime dateTime) {
-    return timeago.format(dateTime);
+    return timeago.format(dateTime.toLocal());
   }
 
   /// Format as relative time with short format "2h", "5m"
+  /// Converts to local timezone before calculating relative time
   static String relativeShort(DateTime dateTime) {
-    return timeago.format(dateTime, locale: 'en_short');
+    return timeago.format(dateTime.toLocal(), locale: 'en_short');
   }
 
   /// Format time range "3:00 PM - 4:00 PM"
+  /// Converts to local timezone before formatting
   static String timeRange(DateTime start, DateTime end) {
     return '${time(start)} - ${time(end)}';
   }

--- a/lib/data/datasources/remote/booking_remote_source.dart
+++ b/lib/data/datasources/remote/booking_remote_source.dart
@@ -17,10 +17,14 @@ BookingRemoteSource bookingRemoteSource(Ref ref) {
 /// Remote data source interface for booking operations
 abstract class BookingRemoteSource {
   /// Get consultant availability for a date range
+  ///
+  /// [planId] and [planType] are used to determine slot duration.
   Future<List<DayAvailability>> getConsultantAvailability({
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
+    String? planId,
+    String? planType,
   });
 
   /// Get user's bookings with pagination and optional status filter
@@ -65,14 +69,24 @@ class BookingRemoteSourceImpl implements BookingRemoteSource {
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
+    String? planId,
+    String? planType,
   }) async {
     try {
+      final queryParams = <String, dynamic>{
+        'startDate': startDate.toUtc().toIso8601String(),
+        'endDate': endDate.toUtc().toIso8601String(),
+      };
+      if (planId != null) {
+        queryParams['planId'] = planId;
+      }
+      if (planType != null) {
+        queryParams['planType'] = planType;
+      }
+
       final response = await _dio.get(
         '/api/consultants/$consultantProfileId/availability',
-        queryParameters: {
-          'startDate': startDate.toUtc().toIso8601String(),
-          'endDate': endDate.toUtc().toIso8601String(),
-        },
+        queryParameters: queryParams,
       );
 
       if (response.statusCode == 200) {

--- a/lib/data/repositories/booking_repository_impl.dart
+++ b/lib/data/repositories/booking_repository_impl.dart
@@ -27,11 +27,15 @@ class BookingRepositoryImpl implements BookingRepository {
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
+    String? planId,
+    String? planType,
   }) {
     return _remoteSource.getConsultantAvailability(
       consultantProfileId: consultantProfileId,
       startDate: startDate,
       endDate: endDate,
+      planId: planId,
+      planType: planType,
     );
   }
 

--- a/lib/domain/entities/booking/availability.dart
+++ b/lib/domain/entities/booking/availability.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../core/utils/formatters.dart';
+
 part 'availability.freezed.dart';
 part 'availability.g.dart';
 
@@ -24,20 +26,7 @@ class AvailabilitySlot with _$AvailabilitySlot {
 
   /// Formatted time range (e.g., "9:00 AM - 10:00 AM")
   /// Times are converted from UTC to local timezone for display
-  String get formattedTimeRange {
-    final localStart = startsAt.toLocal();
-    final localEnd = endsAt.toLocal();
-
-    final startHour = localStart.hour % 12 == 0 ? 12 : localStart.hour % 12;
-    final startMin = localStart.minute.toString().padLeft(2, '0');
-    final startPeriod = localStart.hour < 12 ? 'AM' : 'PM';
-
-    final endHour = localEnd.hour % 12 == 0 ? 12 : localEnd.hour % 12;
-    final endMin = localEnd.minute.toString().padLeft(2, '0');
-    final endPeriod = localEnd.hour < 12 ? 'AM' : 'PM';
-
-    return '$startHour:$startMin $startPeriod - $endHour:$endMin $endPeriod';
-  }
+  String get formattedTimeRange => Formatters.timeRange(startsAt, endsAt);
 
   /// Whether this slot is in the past (compares UTC times)
   bool get isPast => startsAt.isBefore(DateTime.now().toUtc());

--- a/lib/domain/entities/booking/availability.dart
+++ b/lib/domain/entities/booking/availability.dart
@@ -23,20 +23,24 @@ class AvailabilitySlot with _$AvailabilitySlot {
   Duration get duration => endsAt.difference(startsAt);
 
   /// Formatted time range (e.g., "9:00 AM - 10:00 AM")
+  /// Times are converted from UTC to local timezone for display
   String get formattedTimeRange {
-    final startHour = startsAt.hour % 12 == 0 ? 12 : startsAt.hour % 12;
-    final startMin = startsAt.minute.toString().padLeft(2, '0');
-    final startPeriod = startsAt.hour < 12 ? 'AM' : 'PM';
+    final localStart = startsAt.toLocal();
+    final localEnd = endsAt.toLocal();
 
-    final endHour = endsAt.hour % 12 == 0 ? 12 : endsAt.hour % 12;
-    final endMin = endsAt.minute.toString().padLeft(2, '0');
-    final endPeriod = endsAt.hour < 12 ? 'AM' : 'PM';
+    final startHour = localStart.hour % 12 == 0 ? 12 : localStart.hour % 12;
+    final startMin = localStart.minute.toString().padLeft(2, '0');
+    final startPeriod = localStart.hour < 12 ? 'AM' : 'PM';
+
+    final endHour = localEnd.hour % 12 == 0 ? 12 : localEnd.hour % 12;
+    final endMin = localEnd.minute.toString().padLeft(2, '0');
+    final endPeriod = localEnd.hour < 12 ? 'AM' : 'PM';
 
     return '$startHour:$startMin $startPeriod - $endHour:$endMin $endPeriod';
   }
 
-  /// Whether this slot is in the past
-  bool get isPast => startsAt.isBefore(DateTime.now());
+  /// Whether this slot is in the past (compares UTC times)
+  bool get isPast => startsAt.isBefore(DateTime.now().toUtc());
 
   /// Whether this slot is available for booking
   bool get isAvailable => !isBooked && !isTentative && !isPast;
@@ -63,7 +67,9 @@ class DayAvailability with _$DayAvailability {
   bool get hasAvailableSlots => availableSlots.isNotEmpty;
 
   /// Formatted date (e.g., "Mon, Jan 15")
+  /// Date is converted from UTC to local timezone for display
   String get formattedDate {
+    final localDate = date.toLocal();
     const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
     const months = [
       'Jan',
@@ -79,9 +85,9 @@ class DayAvailability with _$DayAvailability {
       'Nov',
       'Dec',
     ];
-    final weekday = weekdays[date.weekday - 1];
-    final month = months[date.month - 1];
-    return '$weekday, $month ${date.day}';
+    final weekday = weekdays[localDate.weekday - 1];
+    final month = months[localDate.month - 1];
+    return '$weekday, $month ${localDate.day}';
   }
 }
 

--- a/lib/domain/entities/booking/booking.dart
+++ b/lib/domain/entities/booking/booking.dart
@@ -142,7 +142,9 @@ class BookingSlot with _$BookingSlot {
       _$BookingSlotFromJson(json);
 
   /// Formatted date (e.g., "Mon, Jan 15")
+  /// Date is converted from UTC to local timezone for display
   String get formattedDate {
+    final localStart = startsAt.toLocal();
     const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
     const months = [
       'Jan',
@@ -158,20 +160,24 @@ class BookingSlot with _$BookingSlot {
       'Nov',
       'Dec',
     ];
-    final weekday = weekdays[startsAt.weekday - 1];
-    final month = months[startsAt.month - 1];
-    return '$weekday, $month ${startsAt.day}';
+    final weekday = weekdays[localStart.weekday - 1];
+    final month = months[localStart.month - 1];
+    return '$weekday, $month ${localStart.day}';
   }
 
   /// Formatted time range
+  /// Times are converted from UTC to local timezone for display
   String get formattedTimeRange {
-    final startHour = startsAt.hour % 12 == 0 ? 12 : startsAt.hour % 12;
-    final startMin = startsAt.minute.toString().padLeft(2, '0');
-    final startPeriod = startsAt.hour < 12 ? 'AM' : 'PM';
+    final localStart = startsAt.toLocal();
+    final localEnd = endsAt.toLocal();
 
-    final endHour = endsAt.hour % 12 == 0 ? 12 : endsAt.hour % 12;
-    final endMin = endsAt.minute.toString().padLeft(2, '0');
-    final endPeriod = endsAt.hour < 12 ? 'AM' : 'PM';
+    final startHour = localStart.hour % 12 == 0 ? 12 : localStart.hour % 12;
+    final startMin = localStart.minute.toString().padLeft(2, '0');
+    final startPeriod = localStart.hour < 12 ? 'AM' : 'PM';
+
+    final endHour = localEnd.hour % 12 == 0 ? 12 : localEnd.hour % 12;
+    final endMin = localEnd.minute.toString().padLeft(2, '0');
+    final endPeriod = localEnd.hour < 12 ? 'AM' : 'PM';
 
     return '$startHour:$startMin $startPeriod - $endHour:$endMin $endPeriod';
   }

--- a/lib/domain/entities/booking/booking.dart
+++ b/lib/domain/entities/booking/booking.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../core/utils/formatters.dart';
+
 part 'booking.freezed.dart';
 part 'booking.g.dart';
 
@@ -167,20 +169,7 @@ class BookingSlot with _$BookingSlot {
 
   /// Formatted time range
   /// Times are converted from UTC to local timezone for display
-  String get formattedTimeRange {
-    final localStart = startsAt.toLocal();
-    final localEnd = endsAt.toLocal();
-
-    final startHour = localStart.hour % 12 == 0 ? 12 : localStart.hour % 12;
-    final startMin = localStart.minute.toString().padLeft(2, '0');
-    final startPeriod = localStart.hour < 12 ? 'AM' : 'PM';
-
-    final endHour = localEnd.hour % 12 == 0 ? 12 : localEnd.hour % 12;
-    final endMin = localEnd.minute.toString().padLeft(2, '0');
-    final endPeriod = localEnd.hour < 12 ? 'AM' : 'PM';
-
-    return '$startHour:$startMin $startPeriod - $endHour:$endMin $endPeriod';
-  }
+  String get formattedTimeRange => Formatters.timeRange(startsAt, endsAt);
 }
 
 /// Request to create a consultation booking

--- a/lib/domain/entities/explore/review.dart
+++ b/lib/domain/entities/explore/review.dart
@@ -19,10 +19,12 @@ class Review with _$Review {
   factory Review.fromJson(Map<String, dynamic> json) => _$ReviewFromJson(json);
 
   /// Time ago string (e.g., "2 days ago")
+  /// Converts to local timezone before calculating relative time
   String get timeAgo {
     if (createdAt == null) return '';
+    final localCreatedAt = createdAt!.toLocal();
     final now = DateTime.now();
-    final diff = now.difference(createdAt!);
+    final diff = now.difference(localCreatedAt);
 
     if (diff.inDays > 365) {
       final years = (diff.inDays / 365).floor();

--- a/lib/domain/repositories/booking_repository.dart
+++ b/lib/domain/repositories/booking_repository.dart
@@ -3,10 +3,14 @@ import '../entities/booking/booking_entities.dart';
 /// Repository interface for booking operations
 abstract class BookingRepository {
   /// Get consultant availability for a date range
+  ///
+  /// [planId] and [planType] are used to determine slot duration.
   Future<List<DayAvailability>> getConsultantAvailability({
     required String consultantProfileId,
     required DateTime startDate,
     required DateTime endDate,
+    String? planId,
+    String? planType,
   });
 
   /// Get user's bookings with pagination and optional status filter

--- a/lib/features/booking/providers/availability_provider.dart
+++ b/lib/features/booking/providers/availability_provider.dart
@@ -11,11 +11,15 @@ class AvailabilityParams {
   final String consultantProfileId;
   final DateTime startDate;
   final DateTime endDate;
+  final String? planId;
+  final String? planType;
 
   const AvailabilityParams({
     required this.consultantProfileId,
     required this.startDate,
     required this.endDate,
+    this.planId,
+    this.planType,
   });
 
   @override
@@ -24,12 +28,18 @@ class AvailabilityParams {
     return other is AvailabilityParams &&
         other.consultantProfileId == consultantProfileId &&
         other.startDate == startDate &&
-        other.endDate == endDate;
+        other.endDate == endDate &&
+        other.planId == planId &&
+        other.planType == planType;
   }
 
   @override
   int get hashCode =>
-      consultantProfileId.hashCode ^ startDate.hashCode ^ endDate.hashCode;
+      consultantProfileId.hashCode ^
+      startDate.hashCode ^
+      endDate.hashCode ^
+      planId.hashCode ^
+      planType.hashCode;
 }
 
 /// Provider for fetching consultant availability
@@ -43,6 +53,8 @@ Future<List<DayAvailability>> consultantAvailability(
     consultantProfileId: params.consultantProfileId,
     startDate: params.startDate,
     endDate: params.endDate,
+    planId: params.planId,
+    planType: params.planType,
   );
 }
 

--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -127,10 +127,20 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
           _buildPlanInfoCard(theme),
           const SizedBox(height: 16),
 
-          // Date selection
-          Text(
-            'Select Date',
-            style: theme.textTheme.titleMedium,
+          // Date selection with calendar picker
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Select Date',
+                style: theme.textTheme.titleMedium,
+              ),
+              IconButton(
+                icon: const Icon(Icons.calendar_month),
+                tooltip: 'Pick a date',
+                onPressed: () => _showDatePickerDialog(context),
+              ),
+            ],
           ),
           const SizedBox(height: 8),
           _buildDateSelector(theme),
@@ -700,13 +710,16 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
               ],
               if (description != null && description.isNotEmpty) ...[
                 const SizedBox(height: 8),
-                Text(
-                  description,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 100),
+                  child: SingleChildScrollView(
+                    child: Text(
+                      description,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
                   ),
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
                 ),
               ],
             ],
@@ -741,6 +754,23 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
         ],
       ),
     );
+  }
+
+  Future<void> _showDatePickerDialog(BuildContext context) async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365)),
+      helpText: 'Select a date',
+    );
+    if (picked != null && mounted) {
+      setState(() {
+        _selectedDate = picked;
+        _selectedSlot = null; // Clear selected slot when date changes
+      });
+    }
   }
 
   void _handleConsultationBooking() {

--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../domain/entities/booking/booking_entities.dart';
+import '../../../domain/entities/explore/consultation_plan.dart';
+import '../../../domain/entities/explore/subscription_plan.dart';
 import '../../../shared/widgets/timezone_indicator.dart';
+import '../../explore/providers/consultant_detail_provider.dart';
 import '../providers/availability_provider.dart';
 import '../providers/booking_flow_provider.dart';
 
@@ -120,6 +123,10 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Plan info card
+          _buildPlanInfoCard(theme),
+          const SizedBox(height: 16),
+
           // Date selection
           Text(
             'Select Date',
@@ -187,6 +194,10 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Plan info card
+          _buildPlanInfoCard(theme),
+          const SizedBox(height: 16),
+
           // Info card
           Card(
             child: Padding(
@@ -587,6 +598,123 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
           borderRadius: BorderRadius.circular(12),
         ),
       ),
+    );
+  }
+
+  Widget _buildPlanInfoCard(ThemeData theme) {
+    final consultantAsync = ref.watch(consultantDetailsProvider(widget.consultantId));
+
+    return consultantAsync.when(
+      data: (consultant) {
+        if (consultant == null) return const SizedBox.shrink();
+
+        final isConsultation = widget.planType == 'consultation';
+        String? title;
+        String? description;
+        String? duration;
+        String? price;
+
+        if (isConsultation) {
+          final plan = consultant.consultationPlans.cast<ConsultationPlan?>().firstWhere(
+            (p) => p?.id == widget.planId,
+            orElse: () => null,
+          );
+          if (plan != null) {
+            title = plan.title;
+            description = plan.description;
+            duration = plan.formattedDuration;
+            price = plan.formattedPrice;
+          }
+        } else {
+          final plan = consultant.subscriptionPlans.cast<SubscriptionPlan?>().firstWhere(
+            (p) => p?.id == widget.planId,
+            orElse: () => null,
+          );
+          if (plan != null) {
+            title = plan.title;
+            description = plan.description;
+            duration = plan.formattedDuration;
+            price = plan.formattedPrice;
+          }
+        }
+
+        if (title == null) return const SizedBox.shrink();
+
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: theme.colorScheme.primary.withValues(alpha: 0.2),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      price ?? '',
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: theme.colorScheme.onPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              if (duration != null) ...[
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.schedule,
+                      size: 14,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      duration,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+              if (description != null && description.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Text(
+                  description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
     );
   }
 

--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -109,6 +109,8 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
           consultantProfileId: widget.consultantId,
           startDate: startDate,
           endDate: endDate,
+          planId: widget.planId,
+          planType: widget.planType,
         ),
       ),
     );
@@ -391,9 +393,9 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
       orElse: () => DayAvailability(date: _selectedDate, slots: []),
     );
 
-    final availableSlots = dayAvailability.availableSlots;
+    final allSlots = dayAvailability.slots;
 
-    if (availableSlots.isEmpty) {
+    if (allSlots.isEmpty) {
       return Container(
         padding: const EdgeInsets.all(32),
         decoration: BoxDecoration(
@@ -409,7 +411,7 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              'No available slots for this date',
+              'No slots for this date',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -419,18 +421,106 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
       );
     }
 
-    return Wrap(
-      spacing: 8,
-      runSpacing: 8,
-      children: availableSlots.map((slot) {
-        final isSelected = _selectedSlot?.id == slot.id;
+    // Check if any slots are available
+    final hasAvailableSlots = allSlots.any((s) => s.isAvailable);
 
-        return ChoiceChip(
-          label: Text(slot.formattedTimeRange),
-          selected: isSelected,
-          onSelected: (_) => setState(() => _selectedSlot = slot),
-        );
-      }).toList(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: allSlots.map((slot) {
+            final isSelected = _selectedSlot?.id == slot.id;
+            final isAvailable = slot.isAvailable;
+            final isPast = slot.isPast;
+            final isBooked = slot.isBooked;
+
+            // Color scheme:
+            // - Past: grey
+            // - Booked: dark grey
+            // - Available: light green
+            // - Selected: almost black
+            Color backgroundColor;
+            Color textColor;
+            Color borderColor;
+
+            if (isSelected) {
+              backgroundColor = const Color(0xFF2D2D2D); // Almost black
+              textColor = Colors.white;
+              borderColor = Colors.black;
+            } else if (isPast) {
+              backgroundColor = Colors.grey.shade300;
+              textColor = Colors.grey.shade700;
+              borderColor = Colors.grey.shade400;
+            } else if (isBooked) {
+              backgroundColor = Colors.grey.shade600;
+              textColor = Colors.white;
+              borderColor = Colors.grey.shade700;
+            } else {
+              // Available
+              backgroundColor = Colors.green.shade100;
+              textColor = Colors.green.shade900;
+              borderColor = Colors.green.shade300;
+            }
+
+            return GestureDetector(
+              onTap: isAvailable
+                  ? () => setState(() => _selectedSlot = slot)
+                  : null,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: borderColor,
+                    width: isSelected ? 2 : 1,
+                  ),
+                ),
+                child: Text(
+                  slot.formattedTimeRange,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: textColor,
+                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+        if (!hasAvailableSlots) ...[
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.errorContainer.withValues(alpha: 0.3),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.info_outline,
+                  size: 16,
+                  color: theme.colorScheme.error,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'No available slots for this date. Please select another date.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
     );
   }
 

--- a/lib/features/booking/screens/booking_screen.dart
+++ b/lib/features/booking/screens/booking_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../domain/entities/booking/booking_entities.dart';
+import '../../../shared/widgets/timezone_indicator.dart';
 import '../providers/availability_provider.dart';
 import '../providers/booking_flow_provider.dart';
 
@@ -84,6 +85,12 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(isConsultation ? 'Book Consultation' : 'Book Subscription'),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.only(right: 8),
+            child: TimezoneIndicator(),
+          ),
+        ],
       ),
       body: isConsultation
           ? _buildConsultationBooking(theme, isLoading)
@@ -544,8 +551,14 @@ class _BookingScreenState extends ConsumerState<BookingScreen> {
         );
   }
 
+  /// Compares two dates to check if they represent the same day
+  /// Both dates are converted to local timezone for accurate comparison
   bool _isSameDay(DateTime a, DateTime b) {
-    return a.year == b.year && a.month == b.month && a.day == b.day;
+    final localA = a.toLocal();
+    final localB = b.toLocal();
+    return localA.year == localB.year &&
+        localA.month == localB.month &&
+        localA.day == localB.day;
   }
 
   String _formatDate(DateTime date) {

--- a/lib/features/booking/widgets/booking_card.dart
+++ b/lib/features/booking/widgets/booking_card.dart
@@ -395,9 +395,10 @@ class BookingCard extends StatelessWidget {
     );
   }
 
+  /// Formats the scheduling period date range in local timezone
   String _formatDateRange() {
-    final start = booking.schedulingPeriodStartsAt;
-    final end = booking.schedulingPeriodEndsAt;
+    final start = booking.schedulingPeriodStartsAt?.toLocal();
+    final end = booking.schedulingPeriodEndsAt?.toLocal();
     if (start == null || end == null) return 'TBD';
 
     const months = [
@@ -417,9 +418,12 @@ class BookingCard extends StatelessWidget {
     return '${months[start.month - 1]} ${start.day} - ${months[end.month - 1]} ${end.day}';
   }
 
+  /// Formats a date relative to now (today, yesterday, N days ago, or date)
+  /// Date is converted from UTC to local timezone for comparison
   String _formatRelativeDate(DateTime date) {
+    final localDate = date.toLocal();
     final now = DateTime.now();
-    final diff = now.difference(date);
+    final diff = now.difference(localDate);
 
     if (diff.inDays == 0) {
       return 'today';
@@ -442,7 +446,7 @@ class BookingCard extends StatelessWidget {
         'Nov',
         'Dec',
       ];
-      return '${months[date.month - 1]} ${date.day}';
+      return '${months[localDate.month - 1]} ${localDate.day}';
     }
   }
 }

--- a/lib/shared/widgets/timezone_indicator.dart
+++ b/lib/shared/widgets/timezone_indicator.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+/// A compact widget that displays the current timezone.
+///
+/// Shows the timezone name and UTC offset (e.g., "IST (UTC+5:30)").
+/// Useful for indicating to users what timezone times are displayed in.
+class TimezoneIndicator extends StatelessWidget {
+  const TimezoneIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final now = DateTime.now();
+    final offset = now.timeZoneOffset;
+    final hours = offset.inHours;
+    final minutes = offset.inMinutes.remainder(60).abs();
+    final sign = hours >= 0 ? '+' : '';
+    final tzName = now.timeZoneName; // e.g., "IST", "PST", "EST"
+
+    // Format: "IST (UTC+5:30)" or "PST (UTC-8)"
+    final offsetStr = minutes > 0
+        ? 'UTC$sign$hours:${minutes.toString().padLeft(2, '0')}'
+        : 'UTC$sign$hours';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.schedule,
+            size: 14,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            '$tzName ($offsetStr)',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Comprehensive fixes for the booking system including timezone handling, slot availability algorithm, and conflict detection.

### Timezone Fixes
- Add `.toLocal()` conversion to all date/time formatting methods
- Fix timezone handling in booking entities (availability slots, booking dates)
- Create `TimezoneIndicator` widget showing current timezone (e.g., "IST (UTC+5:30)")
- Use UTC consistently for `DateTime.now()` comparisons in backend

### Slot Algorithm Fixes
- **Window Merging**: Merge consecutive availability windows to allow multi-hour plans (2hr, 4hr) to span multiple 1-hour blocks
- **Plan Sorting**: Sort consultation and subscription plans by duration (1hr → 2hr → 4hr) instead of price
- **Slot Colors**: New color scheme - grey (past), dark grey (booked), light green (available), almost black (selected)

### Critical Conflict Detection Fixes
- **Status Filter**: Exclude CANCELLED/REJECTED/EXPIRED appointments from blocking availability (slots freed on cancellation)
- **Tentative Slots**: Don't block availability for other users (first approval wins)
- **Cross-Midnight**: Fix overnight window reconstruction (10PM-2AM now generates correct slots)
- **Cross-Day Availability**: Use `dayOfWeekForEndsAt` field properly (Mon 10PM → Tue 2AM shows on both days)

## Files Changed

### Backend
| File | Change |
|------|--------|
| `backend/.../slot_repository.dart` | Status filter, tentative handling, cross-midnight fix, cross-day support, UTC consistency |
| `backend/.../consultant_explore_repository.dart` | Sort plans by duration |
| `backend/.../appointment_repository.dart` | Timezone alignment |
| `backend/routes/api/consultants/[id]/availability.dart` | Duration parameter support |

### Frontend
| File | Change |
|------|--------|
| `lib/core/utils/formatters.dart` | Added `.toLocal()` to all date/time methods |
| `lib/domain/entities/booking/availability.dart` | Fixed time slot formatting |
| `lib/features/booking/screens/booking_screen.dart` | New slot colors, timezone indicator |
| `lib/features/booking/providers/availability_provider.dart` | Duration parameter |
| `lib/shared/widgets/timezone_indicator.dart` | NEW - reusable timezone widget |

## Test Plan
- [ ] Cancelled appointments free up slots for rebooking
- [ ] Tentative slots show as available to other users
- [ ] Cross-midnight availability (10PM-2AM) generates correct slots
- [ ] Multi-day weekly availability works (Mon 10PM - Tue 2AM)
- [ ] Past slots correctly marked in all timezones
- [ ] Plans sorted by duration (1hr → 2hr → 4hr)
- [ ] Slot colors: grey=past, dark grey=booked, light green=available
- [ ] 2hr/4hr plans show merged consecutive slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)