### PR TITLE
feat(payments): Webhook redundancy, Stripe support & dispute handling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,5 +23,18 @@ GITHUB_REDIRECT_URI=familiarise://auth/github/callback
 # Get your DSN from https://sentry.io
 SENTRY_DSN=https://your-key@your-org.ingest.sentry.io/project-id
 
+# Razorpay (Payment Gateway - India)
+# Get these from https://dashboard.razorpay.com/app/keys
+RAZORPAY_KEY_ID=rzp_test_xxxxx
+RAZORPAY_KEY_SECRET=your-razorpay-key-secret
+# Webhook secret from Razorpay Dashboard -> Webhooks
+RAZORPAY_WEBHOOK_SECRET=your-razorpay-webhook-secret
+
+# Stripe (Payment Gateway - International)
+# Get these from https://dashboard.stripe.com/apikeys
+STRIPE_SECRET_KEY=sk_test_xxxxx
+# Webhook signing secret from Stripe Dashboard -> Webhooks
+STRIPE_WEBHOOK_SECRET=whsec_xxxxx
+
 # Server
 PORT=8080

--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -479,6 +479,7 @@ class DatabaseClient {
     _checkoutRepository = CheckoutRepository(_executor);
     _webhookEventRepository = WebhookEventRepository(_executor);
     _refundRepository = RefundRepository(_executor);
+    _disputeRepository = DisputeRepository(_executor);
   }
 
   static DatabaseClient? _instance;
@@ -503,6 +504,7 @@ class DatabaseClient {
   late final CheckoutRepository _checkoutRepository;
   late final WebhookEventRepository _webhookEventRepository;
   late final RefundRepository _refundRepository;
+  late final DisputeRepository _disputeRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -596,6 +598,9 @@ class DatabaseClient {
 
   /// Refund repository (for refund tracking)
   RefundRepository get refunds => _refundRepository;
+
+  /// Dispute repository (for dispute visibility)
+  DisputeRepository get disputes => _disputeRepository;
 
   // ==================== Legacy Methods ====================
   // These methods delegate to repositories. They will be deprecated once all

--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -477,6 +477,8 @@ class DatabaseClient {
     _appointmentRepository = AppointmentRepository(_executor);
     _programsRepository = ProgramsRepository(_executor);
     _checkoutRepository = CheckoutRepository(_executor);
+    _webhookEventRepository = WebhookEventRepository(_executor);
+    _refundRepository = RefundRepository(_executor);
   }
 
   static DatabaseClient? _instance;
@@ -499,6 +501,8 @@ class DatabaseClient {
   late final AppointmentRepository _appointmentRepository;
   late final ProgramsRepository _programsRepository;
   late final CheckoutRepository _checkoutRepository;
+  late final WebhookEventRepository _webhookEventRepository;
+  late final RefundRepository _refundRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -586,6 +590,12 @@ class DatabaseClient {
 
   /// Checkout repository (for payment operations)
   CheckoutRepository get checkout => _checkoutRepository;
+
+  /// Webhook event repository (for idempotent webhook processing)
+  WebhookEventRepository get webhookEvents => _webhookEventRepository;
+
+  /// Refund repository (for refund tracking)
+  RefundRepository get refunds => _refundRepository;
 
   // ==================== Legacy Methods ====================
   // These methods delegate to repositories. They will be deprecated once all

--- a/backend/lib/database/repositories/dispute_repository.dart
+++ b/backend/lib/database/repositories/dispute_repository.dart
@@ -1,4 +1,5 @@
 import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/utils/sentry_logger.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
 import 'package:uuid/uuid.dart';
 
@@ -135,7 +136,11 @@ class DisputeRepository extends BaseRepository {
         'isChargeRefundable': isChargeRefundable,
       };
     } catch (e) {
-      // Unique constraint violation - already exists
+      // Log to help diagnose if this is NOT a unique constraint violation
+      SentryLogger.warning(
+        'Error creating dispute (possibly duplicate): $disputeId - $e',
+        context: 'DisputeRepository',
+      );
       return getDisputeByDisputeId(disputeId);
     }
   }

--- a/backend/lib/database/repositories/dispute_repository.dart
+++ b/backend/lib/database/repositories/dispute_repository.dart
@@ -1,0 +1,158 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+import 'package:uuid/uuid.dart';
+
+/// Repository for dispute operations (MVP - read-only visibility)
+///
+/// Disputes are created by web backend from webhooks.
+/// Mobile backend provides read-only access for user visibility.
+class DisputeRepository extends BaseRepository {
+  DisputeRepository(super._executor);
+
+  final _uuid = const Uuid();
+
+  /// Get dispute by gateway-specific dispute ID
+  Future<Map<String, dynamic>?> getDisputeByDisputeId(String disputeId) async {
+    final query = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.findUnique)
+        .where({'disputeId': disputeId}).build();
+
+    return executeQueryAsSingleMap(query);
+  }
+
+  /// Get all disputes for a payment
+  Future<List<Map<String, dynamic>>> getDisputesByPaymentId(
+    String paymentId,
+  ) async {
+    final query = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.findMany)
+        .where({'paymentId': paymentId})
+        .orderBy({'createdAt': 'desc'})
+        .build();
+
+    return executeQueryAsMaps(query);
+  }
+
+  /// Get dispute by internal ID
+  Future<Map<String, dynamic>?> getDisputeById(String id) async {
+    final query = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.findUnique)
+        .where({'id': id}).build();
+
+    return executeQueryAsSingleMap(query);
+  }
+
+  /// Get all disputes for a user (via their payments)
+  /// Useful for "My Disputes" screen
+  Future<List<Map<String, dynamic>>> getDisputesByUserId(String userId) async {
+    final query = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.findMany)
+        .where({
+          'payment': {
+            'userId': userId,
+          },
+        })
+        .include({
+          'payment': {
+            'select': {
+              'id': true,
+              'amount': true,
+              'currency': true,
+            },
+          },
+        })
+        .orderBy({'createdAt': 'desc'})
+        .build();
+
+    return executeQueryAsMaps(query);
+  }
+
+  // =========================================
+  // WRITE METHODS (for webhook handling)
+  // Note: These exist for completeness but
+  // primary processing happens on web backend
+  // =========================================
+
+  /// Create a new dispute record from webhook event
+  /// Returns the created dispute record or existing if duplicate
+  Future<Map<String, dynamic>?> createDispute({
+    required String disputeId,
+    required String paymentId,
+    required int amount,
+    required String currency,
+    required String reason,
+    required String status,
+    required String paymentGateway,
+    DateTime? dueBy,
+    bool isChargeRefundable = true,
+    Map<String, dynamic>? evidence,
+  }) async {
+    // Check if dispute already exists (idempotency)
+    final existing = await getDisputeByDisputeId(disputeId);
+    if (existing != null) {
+      return existing;
+    }
+
+    final id = _uuid.v4();
+    final now = nowIso8601;
+
+    final createQuery = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.create)
+        .data({
+      'id': id,
+      'disputeId': disputeId,
+      'paymentId': paymentId,
+      'amount': amount,
+      'currency': currency,
+      'reason': reason,
+      'status': status,
+      'paymentGateway': paymentGateway,
+      if (dueBy != null) 'dueBy': dueBy.toIso8601String(),
+      'isChargeRefundable': isChargeRefundable,
+      if (evidence != null) 'evidence': evidence, // Json type - pass object directly
+      'createdAt': now,
+      'updatedAt': now,
+    }).build();
+
+    try {
+      await executeMutation(createQuery);
+
+      return {
+        'id': id,
+        'disputeId': disputeId,
+        'paymentId': paymentId,
+        'amount': amount,
+        'currency': currency,
+        'reason': reason,
+        'status': status,
+        'paymentGateway': paymentGateway,
+        'dueBy': dueBy?.toIso8601String(),
+        'isChargeRefundable': isChargeRefundable,
+      };
+    } catch (e) {
+      // Unique constraint violation - already exists
+      return getDisputeByDisputeId(disputeId);
+    }
+  }
+
+  /// Update dispute status
+  Future<void> updateDisputeStatus({
+    required String disputeId,
+    required String status,
+  }) async {
+    final updateQuery = JsonQueryBuilder()
+        .model('Dispute')
+        .action(QueryAction.update)
+        .where({'disputeId': disputeId}).data({
+      'status': status,
+      'updatedAt': nowIso8601,
+    }).build();
+
+    await executeMutation(updateQuery);
+  }
+}

--- a/backend/lib/database/repositories/refund_repository.dart
+++ b/backend/lib/database/repositories/refund_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/utils/sentry_logger.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
 import 'package:uuid/uuid.dart';
 
@@ -65,7 +66,11 @@ class RefundRepository extends BaseRepository {
         'reason': reason,
       };
     } catch (e) {
-      // Unique constraint violation - already exists
+      // Log to help diagnose if this is NOT a unique constraint violation
+      SentryLogger.warning(
+        'Error creating refund (possibly duplicate): $refundId - $e',
+        context: 'RefundRepository',
+      );
       return getRefundByRefundId(refundId);
     }
   }

--- a/backend/lib/database/repositories/refund_repository.dart
+++ b/backend/lib/database/repositories/refund_repository.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+import 'package:uuid/uuid.dart';
+
+/// Repository for refund operations
+///
+/// Handles creating, querying, and updating refund records from webhook events.
+class RefundRepository extends BaseRepository {
+  RefundRepository(super._executor);
+
+  final _uuid = const Uuid();
+
+  /// Create a new refund record from webhook event
+  ///
+  /// Returns the created refund record or null if already exists (idempotent).
+  Future<Map<String, dynamic>?> createRefund({
+    required String refundId,
+    required String paymentId,
+    required int amount,
+    required String currency,
+    required String status,
+    required String paymentGateway,
+    String? reason,
+    Map<String, dynamic>? metadata,
+  }) async {
+    // Check if refund already exists (idempotency)
+    final existing = await getRefundByRefundId(refundId);
+    if (existing != null) {
+      return existing; // Already processed
+    }
+
+    final id = _uuid.v4();
+    final now = nowIso8601;
+
+    final createQuery = JsonQueryBuilder()
+        .model('Refund')
+        .action(QueryAction.create)
+        .data({
+      'id': id,
+      'refundId': refundId,
+      'paymentId': paymentId,
+      'amount': amount,
+      'currency': currency,
+      'status': status,
+      'paymentGateway': paymentGateway,
+      if (reason != null) 'reason': reason,
+      if (metadata != null) 'metadata': jsonEncode(metadata),
+      'createdAt': now,
+      'updatedAt': now,
+    }).build();
+
+    try {
+      await executeMutation(createQuery);
+
+      return {
+        'id': id,
+        'refundId': refundId,
+        'paymentId': paymentId,
+        'amount': amount,
+        'currency': currency,
+        'status': status,
+        'paymentGateway': paymentGateway,
+        'reason': reason,
+      };
+    } catch (e) {
+      // Unique constraint violation - already exists
+      return getRefundByRefundId(refundId);
+    }
+  }
+
+  /// Get refund by gateway-specific refund ID
+  Future<Map<String, dynamic>?> getRefundByRefundId(String refundId) async {
+    final query = JsonQueryBuilder()
+        .model('Refund')
+        .action(QueryAction.findUnique)
+        .where({'refundId': refundId}).build();
+
+    return executeQueryAsSingleMap(query);
+  }
+
+  /// Get all refunds for a payment
+  Future<List<Map<String, dynamic>>> getRefundsByPaymentId(
+    String paymentId,
+  ) async {
+    final query = JsonQueryBuilder()
+        .model('Refund')
+        .action(QueryAction.findMany)
+        .where({'paymentId': paymentId})
+        .orderBy({'createdAt': 'desc'})
+        .build();
+
+    return executeQueryAsMaps(query);
+  }
+
+  /// Update refund status
+  Future<void> updateRefundStatus({
+    required String refundId,
+    required String status,
+  }) async {
+    final updateQuery = JsonQueryBuilder()
+        .model('Refund')
+        .action(QueryAction.update)
+        .where({'refundId': refundId}).data({
+      'status': status,
+      'updatedAt': nowIso8601,
+    }).build();
+
+    await executeMutation(updateQuery);
+  }
+
+  /// Get refund by internal ID
+  Future<Map<String, dynamic>?> getRefundById(String id) async {
+    final query = JsonQueryBuilder()
+        .model('Refund')
+        .action(QueryAction.findUnique)
+        .where({'id': id}).build();
+
+    return executeQueryAsSingleMap(query);
+  }
+}

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -12,6 +12,8 @@ export 'consultant_profile_repository.dart';
 export 'consultee_profile_repository.dart';
 export 'domain_repository.dart';
 export 'programs_repository.dart';
+export 'refund_repository.dart';
 export 'session_repository.dart';
 export 'slot_repository.dart';
 export 'user_repository.dart';
+export 'webhook_event_repository.dart';

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -10,6 +10,7 @@ export 'checkout_repository.dart';
 export 'consultant_explore_repository.dart';
 export 'consultant_profile_repository.dart';
 export 'consultee_profile_repository.dart';
+export 'dispute_repository.dart';
 export 'domain_repository.dart';
 export 'programs_repository.dart';
 export 'refund_repository.dart';

--- a/backend/lib/database/repositories/webhook_event_repository.dart
+++ b/backend/lib/database/repositories/webhook_event_repository.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for webhook event tracking and idempotency
+///
+/// This repository handles storing and checking webhook events to prevent
+/// duplicate processing when both mobile and web backends receive the same webhook.
+class WebhookEventRepository extends BaseRepository {
+  WebhookEventRepository(super._executor);
+
+  /// Record a webhook event and check if it was already processed
+  ///
+  /// Returns true if this is a new event that should be processed.
+  /// Returns false if the event was already processed (duplicate).
+  ///
+  /// This method is idempotent - calling it multiple times with the same
+  /// eventId will only return true on the first call.
+  Future<bool> recordEvent({
+    required String eventId,
+    required String provider,
+    required String eventType,
+    required Map<String, dynamic> payload,
+    String? signature,
+  }) async {
+    // First check if event already exists
+    final existingEvent = await _findByEventId(eventId);
+    if (existingEvent != null) {
+      return false; // Already processed
+    }
+
+    // Try to create the event record
+    // If another process created it first, this will fail with unique constraint violation
+    try {
+      final createQuery = JsonQueryBuilder()
+          .model('WebhookEvent')
+          .action(QueryAction.create)
+          .data({
+        'eventId': eventId,
+        'provider': provider,
+        'eventType': eventType,
+        'payload': jsonEncode(payload),
+        'signature': signature,
+        'processed': false,
+        'receivedAt': nowIso8601,
+      }).build();
+
+      await executeMutation(createQuery);
+      return true; // New event, should be processed
+    } catch (e) {
+      // Unique constraint violation - another process got there first
+      // This is expected behavior in a distributed system
+      return false;
+    }
+  }
+
+  /// Check if an event has already been processed
+  Future<bool> isEventProcessed(String eventId) async {
+    final event = await _findByEventId(eventId);
+    return event != null;
+  }
+
+  /// Mark an event as successfully processed
+  Future<void> markProcessed(String eventId) async {
+    final updateQuery = JsonQueryBuilder()
+        .model('WebhookEvent')
+        .action(QueryAction.update)
+        .where({'eventId': eventId}).data({
+      'processed': true,
+      'processedAt': nowIso8601,
+    }).build();
+
+    await executeMutation(updateQuery);
+  }
+
+  /// Mark an event as failed with error message
+  Future<void> markFailed(String eventId, String error) async {
+    final updateQuery = JsonQueryBuilder()
+        .model('WebhookEvent')
+        .action(QueryAction.update)
+        .where({'eventId': eventId}).data({
+      'processed': false,
+      'error': error,
+    }).build();
+
+    await executeMutation(updateQuery);
+  }
+
+  /// Find an event by its gateway-specific ID
+  Future<Map<String, dynamic>?> _findByEventId(String eventId) async {
+    final query = JsonQueryBuilder()
+        .model('WebhookEvent')
+        .action(QueryAction.findUnique)
+        .where({'eventId': eventId}).build();
+
+    return executeQueryAsSingleMap(query);
+  }
+
+  /// Get all unprocessed events (for retry mechanisms)
+  Future<List<Map<String, dynamic>>> getUnprocessedEvents({
+    String? provider,
+    int limit = 100,
+  }) async {
+    final whereClause = <String, dynamic>{
+      'processed': false,
+    };
+
+    if (provider != null) {
+      whereClause['provider'] = provider;
+    }
+
+    final query = JsonQueryBuilder()
+        .model('WebhookEvent')
+        .action(QueryAction.findMany)
+        .where(whereClause)
+        .orderBy({'receivedAt': 'asc'})
+        .take(limit)
+        .build();
+
+    return executeQueryAsMaps(query);
+  }
+}

--- a/backend/lib/database/repositories/webhook_event_repository.dart
+++ b/backend/lib/database/repositories/webhook_event_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:backend/database/repositories/base_repository.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
 
@@ -40,7 +38,7 @@ class WebhookEventRepository extends BaseRepository {
         'eventId': eventId,
         'provider': provider,
         'eventType': eventType,
-        'payload': jsonEncode(payload),
+        'payload': payload, // Json type - pass object directly
         'signature': signature,
         'processed': false,
         'receivedAt': nowIso8601,

--- a/backend/lib/database/repositories/webhook_event_repository.dart
+++ b/backend/lib/database/repositories/webhook_event_repository.dart
@@ -1,4 +1,5 @@
 import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/utils/sentry_logger.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// Repository for webhook event tracking and idempotency
@@ -47,14 +48,18 @@ class WebhookEventRepository extends BaseRepository {
       await executeMutation(createQuery);
       return true; // New event, should be processed
     } catch (e) {
-      // Unique constraint violation - another process got there first
-      // This is expected behavior in a distributed system
+      // Log to help diagnose if this is NOT a unique constraint violation
+      // Unique constraint violations are expected in distributed systems
+      SentryLogger.warning(
+        'Error recording webhook event (possibly duplicate): $eventId - $e',
+        context: 'WebhookEventRepository',
+      );
       return false;
     }
   }
 
-  /// Check if an event has already been processed
-  Future<bool> isEventProcessed(String eventId) async {
+  /// Check if an event has been recorded in the database
+  Future<bool> isEventRecorded(String eventId) async {
     final event = await _findByEventId(eventId);
     return event != null;
   }

--- a/backend/lib/database/repositories/webhook_event_repository.dart
+++ b/backend/lib/database/repositories/webhook_event_repository.dart
@@ -1,6 +1,7 @@
 import 'package:backend/database/repositories/base_repository.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
+import 'package:uuid/uuid.dart';
 
 /// Repository for webhook event tracking and idempotency
 ///
@@ -32,10 +33,12 @@ class WebhookEventRepository extends BaseRepository {
     // Try to create the event record
     // If another process created it first, this will fail with unique constraint violation
     try {
+      const uuid = Uuid();
       final createQuery = JsonQueryBuilder()
           .model('WebhookEvent')
           .action(QueryAction.create)
           .data({
+        'id': uuid.v4(), // Generate UUID for id field
         'eventId': eventId,
         'provider': provider,
         'eventType': eventType,

--- a/backend/lib/services/razorpay_service.dart
+++ b/backend/lib/services/razorpay_service.dart
@@ -1,22 +1,22 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
 
 /// Service for interacting with Razorpay API
+///
+/// Uses package:http for HTTP requests - no manual lifecycle management needed.
 class RazorpayService {
   static const String _baseUrl = 'https://api.razorpay.com/v1';
 
   final String _keyId;
   final String _keySecret;
-  final HttpClient _httpClient;
 
   RazorpayService({
     required String keyId,
     required String keySecret,
   })  : _keyId = keyId,
-        _keySecret = keySecret,
-        _httpClient = HttpClient();
+        _keySecret = keySecret;
 
   /// Create a new Razorpay order
   ///
@@ -41,28 +41,27 @@ class RazorpayService {
       if (notes != null) 'notes': notes,
     };
 
-    final request = await _httpClient.postUrl(uri);
-
-    // Add Basic Auth header
+    // Basic Auth header
     final credentials = base64Encode(utf8.encode('$_keyId:$_keySecret'));
-    request.headers.set('Authorization', 'Basic $credentials');
-    request.headers.contentType = ContentType.json;
 
-    // Write body
-    request.write(jsonEncode(body));
-
-    final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Basic $credentials',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(body),
+    );
 
     if (response.statusCode == 200) {
-      final data = jsonDecode(responseBody) as Map<String, dynamic>;
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
       return RazorpayOrder.fromJson(data);
     }
 
     throw RazorpayException(
       message: 'Failed to create Razorpay order',
       statusCode: response.statusCode,
-      responseBody: responseBody,
+      responseBody: response.body,
     );
   }
 
@@ -89,28 +88,23 @@ class RazorpayService {
   Future<Map<String, dynamic>> getPayment(String paymentId) async {
     final uri = Uri.parse('$_baseUrl/payments/$paymentId');
 
-    final request = await _httpClient.getUrl(uri);
-
-    // Add Basic Auth header
+    // Basic Auth header
     final credentials = base64Encode(utf8.encode('$_keyId:$_keySecret'));
-    request.headers.set('Authorization', 'Basic $credentials');
 
-    final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final response = await http.get(
+      uri,
+      headers: {'Authorization': 'Basic $credentials'},
+    );
 
     if (response.statusCode == 200) {
-      return jsonDecode(responseBody) as Map<String, dynamic>;
+      return jsonDecode(response.body) as Map<String, dynamic>;
     }
 
     throw RazorpayException(
       message: 'Failed to fetch payment',
       statusCode: response.statusCode,
-      responseBody: responseBody,
+      responseBody: response.body,
     );
-  }
-
-  void dispose() {
-    _httpClient.close();
   }
 }
 

--- a/backend/lib/services/stripe_service.dart
+++ b/backend/lib/services/stripe_service.dart
@@ -1,0 +1,233 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+/// Service for interacting with Stripe API
+///
+/// Mirrors the RazorpayService pattern - HTTP-based API client without SDK.
+class StripeService {
+  static const String _baseUrl = 'https://api.stripe.com/v1';
+
+  final String _secretKey;
+  final String? _webhookSecret;
+  final HttpClient _httpClient;
+
+  StripeService({
+    required String secretKey,
+    String? webhookSecret,
+  })  : _secretKey = secretKey,
+        _webhookSecret = webhookSecret,
+        _httpClient = HttpClient();
+
+  /// Create a PaymentIntent for mobile checkout
+  ///
+  /// Returns the PaymentIntent with client_secret for frontend SDK.
+  Future<StripePaymentIntent> createPaymentIntent({
+    required int amountInSmallestUnit,
+    required String currency,
+    Map<String, String>? metadata,
+  }) async {
+    final uri = Uri.parse('$_baseUrl/payment_intents');
+
+    // Build form-encoded body
+    final body = <String, String>{
+      'amount': amountInSmallestUnit.toString(),
+      'currency': currency.toLowerCase(),
+      'automatic_payment_methods[enabled]': 'true',
+    };
+
+    // Add metadata fields
+    if (metadata != null) {
+      for (final entry in metadata.entries) {
+        body['metadata[${entry.key}]'] = entry.value;
+      }
+    }
+
+    final request = await _httpClient.postUrl(uri);
+
+    // Bearer token authentication
+    request.headers.set('Authorization', 'Bearer $_secretKey');
+    request.headers.contentType =
+        ContentType('application', 'x-www-form-urlencoded', charset: 'utf-8');
+
+    // Write form-encoded body
+    request.write(_encodeFormData(body));
+
+    final response = await request.close();
+    final responseBody = await response.transform(utf8.decoder).join();
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(responseBody) as Map<String, dynamic>;
+      return StripePaymentIntent.fromJson(data);
+    }
+
+    throw StripeException(
+      message: 'Failed to create Stripe PaymentIntent',
+      statusCode: response.statusCode,
+      responseBody: responseBody,
+    );
+  }
+
+  /// Verify webhook signature (Stripe-Signature header)
+  ///
+  /// Stripe signature format: t=timestamp,v1=signature
+  /// Message to sign: timestamp.payload
+  bool verifyWebhookSignature({
+    required String payload,
+    required String signature,
+  }) {
+    if (_webhookSecret == null) {
+      throw StripeException(
+        message: 'Webhook secret not configured',
+      );
+    }
+
+    // Parse signature header
+    String? timestamp;
+    String? expectedSignature;
+
+    final parts = signature.split(',');
+    for (final part in parts) {
+      final kv = part.split('=');
+      if (kv.length == 2) {
+        if (kv[0] == 't') {
+          timestamp = kv[1];
+        } else if (kv[0] == 'v1') {
+          expectedSignature = kv[1];
+        }
+      }
+    }
+
+    if (timestamp == null || expectedSignature == null) {
+      return false;
+    }
+
+    // Verify timestamp is recent (within 5 minutes)
+    final eventTime = int.tryParse(timestamp);
+    if (eventTime == null) return false;
+
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    if ((now - eventTime).abs() > 300) {
+      return false; // Reject events older than 5 minutes
+    }
+
+    // Compute expected signature
+    final signedPayload = '$timestamp.$payload';
+    final hmac = Hmac(sha256, utf8.encode(_webhookSecret!));
+    final digest = hmac.convert(utf8.encode(signedPayload));
+    final computedSignature = digest.toString();
+
+    return computedSignature == expectedSignature;
+  }
+
+  /// Fetch PaymentIntent details
+  Future<Map<String, dynamic>> getPaymentIntent(String paymentIntentId) async {
+    final uri = Uri.parse('$_baseUrl/payment_intents/$paymentIntentId');
+
+    final request = await _httpClient.getUrl(uri);
+    request.headers.set('Authorization', 'Bearer $_secretKey');
+
+    final response = await request.close();
+    final responseBody = await response.transform(utf8.decoder).join();
+
+    if (response.statusCode == 200) {
+      return jsonDecode(responseBody) as Map<String, dynamic>;
+    }
+
+    throw StripeException(
+      message: 'Failed to fetch PaymentIntent',
+      statusCode: response.statusCode,
+      responseBody: responseBody,
+    );
+  }
+
+  /// Cancel a PaymentIntent
+  Future<void> cancelPaymentIntent(String paymentIntentId) async {
+    final uri = Uri.parse('$_baseUrl/payment_intents/$paymentIntentId/cancel');
+
+    final request = await _httpClient.postUrl(uri);
+    request.headers.set('Authorization', 'Bearer $_secretKey');
+    request.headers.contentType =
+        ContentType('application', 'x-www-form-urlencoded', charset: 'utf-8');
+
+    final response = await request.close();
+
+    if (response.statusCode != 200) {
+      final responseBody = await response.transform(utf8.decoder).join();
+      throw StripeException(
+        message: 'Failed to cancel PaymentIntent',
+        statusCode: response.statusCode,
+        responseBody: responseBody,
+      );
+    }
+  }
+
+  /// Encode form data for x-www-form-urlencoded
+  String _encodeFormData(Map<String, String> data) {
+    return data.entries
+        .map((e) =>
+            '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
+        .join('&');
+  }
+
+  void dispose() {
+    _httpClient.close();
+  }
+}
+
+/// Stripe PaymentIntent response
+class StripePaymentIntent {
+  final String id;
+  final String clientSecret;
+  final int amount;
+  final String currency;
+  final String status;
+  final Map<String, dynamic>? metadata;
+
+  StripePaymentIntent({
+    required this.id,
+    required this.clientSecret,
+    required this.amount,
+    required this.currency,
+    required this.status,
+    this.metadata,
+  });
+
+  factory StripePaymentIntent.fromJson(Map<String, dynamic> json) {
+    return StripePaymentIntent(
+      id: json['id'] as String,
+      clientSecret: json['client_secret'] as String,
+      amount: json['amount'] as int,
+      currency: json['currency'] as String,
+      status: json['status'] as String,
+      metadata: json['metadata'] as Map<String, dynamic>?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'client_secret': clientSecret,
+        'amount': amount,
+        'currency': currency,
+        'status': status,
+        'metadata': metadata,
+      };
+}
+
+/// Stripe API exception
+class StripeException implements Exception {
+  final String message;
+  final int? statusCode;
+  final String? responseBody;
+
+  StripeException({
+    required this.message,
+    this.statusCode,
+    this.responseBody,
+  });
+
+  @override
+  String toString() =>
+      'StripeException: $message (status: $statusCode, response: $responseBody)';
+}

--- a/backend/lib/services/stripe_service.dart
+++ b/backend/lib/services/stripe_service.dart
@@ -1,24 +1,22 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
 
 /// Service for interacting with Stripe API
 ///
-/// Mirrors the RazorpayService pattern - HTTP-based API client without SDK.
+/// Uses package:http for HTTP requests - no manual lifecycle management needed.
 class StripeService {
   static const String _baseUrl = 'https://api.stripe.com/v1';
 
   final String _secretKey;
   final String? _webhookSecret;
-  final HttpClient _httpClient;
 
   StripeService({
     required String secretKey,
     String? webhookSecret,
   })  : _secretKey = secretKey,
-        _webhookSecret = webhookSecret,
-        _httpClient = HttpClient();
+        _webhookSecret = webhookSecret;
 
   /// Create a PaymentIntent for mobile checkout
   ///
@@ -44,28 +42,24 @@ class StripeService {
       }
     }
 
-    final request = await _httpClient.postUrl(uri);
-
-    // Bearer token authentication
-    request.headers.set('Authorization', 'Bearer $_secretKey');
-    request.headers.contentType =
-        ContentType('application', 'x-www-form-urlencoded', charset: 'utf-8');
-
-    // Write form-encoded body
-    request.write(_encodeFormData(body));
-
-    final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $_secretKey',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body,
+    );
 
     if (response.statusCode == 200) {
-      final data = jsonDecode(responseBody) as Map<String, dynamic>;
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
       return StripePaymentIntent.fromJson(data);
     }
 
     throw StripeException(
       message: 'Failed to create Stripe PaymentIntent',
       statusCode: response.statusCode,
-      responseBody: responseBody,
+      responseBody: response.body,
     );
   }
 
@@ -125,20 +119,19 @@ class StripeService {
   Future<Map<String, dynamic>> getPaymentIntent(String paymentIntentId) async {
     final uri = Uri.parse('$_baseUrl/payment_intents/$paymentIntentId');
 
-    final request = await _httpClient.getUrl(uri);
-    request.headers.set('Authorization', 'Bearer $_secretKey');
-
-    final response = await request.close();
-    final responseBody = await response.transform(utf8.decoder).join();
+    final response = await http.get(
+      uri,
+      headers: {'Authorization': 'Bearer $_secretKey'},
+    );
 
     if (response.statusCode == 200) {
-      return jsonDecode(responseBody) as Map<String, dynamic>;
+      return jsonDecode(response.body) as Map<String, dynamic>;
     }
 
     throw StripeException(
       message: 'Failed to fetch PaymentIntent',
       statusCode: response.statusCode,
-      responseBody: responseBody,
+      responseBody: response.body,
     );
   }
 
@@ -146,33 +139,21 @@ class StripeService {
   Future<void> cancelPaymentIntent(String paymentIntentId) async {
     final uri = Uri.parse('$_baseUrl/payment_intents/$paymentIntentId/cancel');
 
-    final request = await _httpClient.postUrl(uri);
-    request.headers.set('Authorization', 'Bearer $_secretKey');
-    request.headers.contentType =
-        ContentType('application', 'x-www-form-urlencoded', charset: 'utf-8');
-
-    final response = await request.close();
+    final response = await http.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $_secretKey',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    );
 
     if (response.statusCode != 200) {
-      final responseBody = await response.transform(utf8.decoder).join();
       throw StripeException(
         message: 'Failed to cancel PaymentIntent',
         statusCode: response.statusCode,
-        responseBody: responseBody,
+        responseBody: response.body,
       );
     }
-  }
-
-  /// Encode form data for x-www-form-urlencoded
-  String _encodeFormData(Map<String, String> data) {
-    return data.entries
-        .map((e) =>
-            '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}')
-        .join('&');
-  }
-
-  void dispose() {
-    _httpClient.close();
   }
 }
 

--- a/backend/lib/services/webhook_handlers.dart
+++ b/backend/lib/services/webhook_handlers.dart
@@ -1,0 +1,227 @@
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Shared webhook handlers for payment gateway events
+///
+/// This service contains business logic that is shared between
+/// Razorpay and Stripe webhook endpoints.
+class WebhookHandlers {
+  final DatabaseClient _db;
+
+  WebhookHandlers(this._db);
+
+  /// Handle successful payment from webhook
+  ///
+  /// Called by both Razorpay payment.captured and Stripe payment_intent.succeeded
+  ///
+  /// [paymentIntentOrOrderId] - The payment intent (Stripe) or order ID (Razorpay)
+  /// [gateway] - The payment gateway ("RAZORPAY" or "STRIPE")
+  Future<void> handlePaymentSuccess({
+    required String paymentIntentOrOrderId,
+    required String gateway,
+  }) async {
+    SentryLogger.info(
+      'Processing payment success via webhook: $paymentIntentOrOrderId',
+      context: 'WebhookHandlers',
+    );
+
+    // Find payment by paymentIntent field
+    final payment = await _findPaymentByIntent(paymentIntentOrOrderId);
+    if (payment == null) {
+      SentryLogger.error(
+        'Payment not found for webhook: $paymentIntentOrOrderId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    final paymentId = payment['id'] as String;
+    final appointmentId = payment['appointmentId'] as String?;
+    final currentStatus = payment['paymentStatus'] as String?;
+
+    // Skip if already processed
+    if (currentStatus == 'SUCCEEDED') {
+      SentryLogger.info(
+        'Payment already succeeded, skipping: $paymentId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    // Update payment status to SUCCEEDED
+    await _db.checkout.updatePaymentStatus(
+      paymentId: paymentId,
+      status: 'SUCCEEDED',
+    );
+
+    // Update booking status and confirm slots
+    if (appointmentId != null) {
+      await _confirmBooking(appointmentId);
+    }
+
+    SentryLogger.info(
+      'Payment confirmed via webhook: $paymentId ($gateway)',
+      context: 'WebhookHandlers',
+    );
+  }
+
+  /// Handle failed payment from webhook
+  ///
+  /// Called by both Razorpay payment.failed and Stripe payment_intent.payment_failed
+  Future<void> handlePaymentFailure({
+    required String paymentIntentOrOrderId,
+    required String gateway,
+    String? reason,
+  }) async {
+    SentryLogger.info(
+      'Processing payment failure via webhook: $paymentIntentOrOrderId',
+      context: 'WebhookHandlers',
+    );
+
+    final payment = await _findPaymentByIntent(paymentIntentOrOrderId);
+    if (payment == null) {
+      SentryLogger.warning(
+        'Payment not found for failure webhook: $paymentIntentOrOrderId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    final paymentId = payment['id'] as String;
+    final currentStatus = payment['paymentStatus'] as String?;
+
+    // Skip if already processed
+    if (currentStatus == 'FAILED' || currentStatus == 'SUCCEEDED') {
+      return;
+    }
+
+    // Update payment status to FAILED
+    await _db.checkout.updatePaymentStatus(
+      paymentId: paymentId,
+      status: 'FAILED',
+    );
+
+    SentryLogger.info(
+      'Payment marked failed via webhook: $paymentId, reason: $reason',
+      context: 'WebhookHandlers',
+    );
+  }
+
+  /// Handle refund processed event from webhook
+  ///
+  /// Creates or updates refund record in database
+  Future<void> handleRefundProcessed({
+    required String refundId,
+    required String paymentIntentOrOrderId,
+    required int amount,
+    required String currency,
+    required String status,
+    required String gateway,
+    String? reason,
+  }) async {
+    SentryLogger.info(
+      'Processing refund via webhook: $refundId',
+      context: 'WebhookHandlers',
+    );
+
+    // Find the payment to get paymentId
+    final payment = await _findPaymentByIntent(paymentIntentOrOrderId);
+    if (payment == null) {
+      SentryLogger.error(
+        'Payment not found for refund webhook: $paymentIntentOrOrderId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    final paymentId = payment['id'] as String;
+
+    // Create or update refund record
+    await _db.refunds.createRefund(
+      refundId: refundId,
+      paymentId: paymentId,
+      amount: amount,
+      currency: currency,
+      status: _mapRefundStatus(status),
+      paymentGateway: gateway,
+      reason: reason,
+    );
+
+    SentryLogger.info(
+      'Refund processed: $refundId for payment $paymentId',
+      context: 'WebhookHandlers',
+    );
+  }
+
+  /// Find payment by paymentIntent field
+  Future<Map<String, dynamic>?> _findPaymentByIntent(String paymentIntent) async {
+    final query = JsonQueryBuilder()
+        .model('Payment')
+        .action(QueryAction.findFirst)
+        .where({'paymentIntent': paymentIntent})
+        .build();
+
+    return _db.executor.executeQueryAsSingleMap(query);
+  }
+
+  /// Confirm booking after successful payment
+  Future<void> _confirmBooking(String appointmentId) async {
+    // Get appointment to find booking
+    final appointmentQuery = JsonQueryBuilder()
+        .model('Appointment')
+        .action(QueryAction.findUnique)
+        .where({'id': appointmentId})
+        .build();
+    final appointment =
+        await _db.executor.executeQueryAsSingleMap(appointmentQuery);
+
+    if (appointment == null) {
+      SentryLogger.warning(
+        'Appointment not found for confirmation: $appointmentId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    final consultationId = appointment['consultationId'] as String?;
+    final subscriptionId = appointment['subscriptionId'] as String?;
+
+    if (consultationId != null) {
+      // Update consultation status to SCHEDULED
+      await _db.checkout.updateBookingStatus(
+        bookingId: consultationId,
+        bookingType: 'CONSULTATION',
+        status: 'SCHEDULED',
+      );
+
+      // Confirm slots (mark as non-tentative)
+      await _db.checkout.confirmSlots(consultationId);
+    } else if (subscriptionId != null) {
+      // Update subscription status to SCHEDULED
+      await _db.checkout.updateBookingStatus(
+        bookingId: subscriptionId,
+        bookingType: 'SUBSCRIPTION',
+        status: 'SCHEDULED',
+      );
+    }
+  }
+
+  /// Map gateway-specific refund status to our enum
+  String _mapRefundStatus(String status) {
+    switch (status.toLowerCase()) {
+      case 'succeeded':
+      case 'processed':
+        return 'SUCCEEDED';
+      case 'pending':
+        return 'PENDING';
+      case 'failed':
+        return 'FAILED';
+      case 'cancelled':
+      case 'canceled':
+        return 'CANCELLED';
+      default:
+        return 'PENDING';
+    }
+  }
+}

--- a/backend/lib/services/webhook_handlers.dart
+++ b/backend/lib/services/webhook_handlers.dart
@@ -154,6 +154,55 @@ class WebhookHandlers {
     );
   }
 
+  /// Handle dispute created from webhook
+  ///
+  /// Called by both Razorpay payment.dispute.created and Stripe charge.dispute.created
+  Future<void> handleDisputeCreated({
+    required String paymentIntentOrOrderId,
+    required String disputeId,
+    required int amount,
+    required String currency,
+    required String reason,
+    required String status,
+    required String gateway,
+    DateTime? dueBy,
+    bool isChargeRefundable = true,
+  }) async {
+    SentryLogger.info(
+      'Processing dispute created via webhook: $disputeId',
+      context: 'WebhookHandlers',
+    );
+
+    final payment = await _findPaymentByIntent(paymentIntentOrOrderId);
+    if (payment == null) {
+      SentryLogger.error(
+        'Payment not found for dispute webhook: $paymentIntentOrOrderId',
+        context: 'WebhookHandlers',
+      );
+      return;
+    }
+
+    final paymentId = payment['id'] as String;
+
+    // Create dispute record
+    await _db.disputes.createDispute(
+      disputeId: disputeId,
+      paymentId: paymentId,
+      amount: amount,
+      currency: currency,
+      reason: reason,
+      status: status,
+      paymentGateway: gateway,
+      dueBy: dueBy,
+      isChargeRefundable: isChargeRefundable,
+    );
+
+    SentryLogger.info(
+      'Dispute created: $disputeId for payment $paymentId',
+      context: 'WebhookHandlers',
+    );
+  }
+
   /// Find payment by paymentIntent field
   Future<Map<String, dynamic>?> _findPaymentByIntent(String paymentIntent) async {
     final query = JsonQueryBuilder()

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -93,21 +93,37 @@ model SupportTicket {
   priority    SupportPriority     @default(MEDIUM)
   status      SupportTicketStatus @default(OPEN)
   category    String?
+  issueType   SupportIssueType?
 
   user   User   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId String
 
-  responses SupportResponse[]
+  responses   SupportResponse[]
+  attachments SupportTicketAttachment[]
+
+  // Entity links for Swiggy-style context (link ticket to booking/payment)
+  consultationId String?
+  subscriptionId String?
+  paymentId      String?
+  refundId       String? // If refund was initiated from this ticket
+
+  // Staff assignment
+  assignedToId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([userId])
+  @@index([status])
+  @@index([assignedToId])
+  @@index([consultationId])
+  @@index([paymentId])
 }
 
 model SupportResponse {
-  id      String @id @default(uuid())
-  message String @db.Text
+  id         String  @id @default(uuid())
+  message    String  @db.Text
+  isInternal Boolean @default(false) // Internal notes not visible to user
 
   supportTicket   SupportTicket @relation(fields: [supportTicketId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   supportTicketId String
@@ -119,6 +135,23 @@ model SupportResponse {
   updatedAt DateTime @updatedAt
 
   @@index([supportTicketId])
+}
+
+model SupportTicketAttachment {
+  id           String @id @default(uuid())
+  fileName     String
+  originalName String
+  fileSize     Int
+  mimeType     String
+  fileUrl      String
+  storagePath  String
+
+  ticket   SupportTicket @relation(fields: [ticketId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  ticketId String
+
+  uploadedAt DateTime @default(now())
+
+  @@index([ticketId])
 }
 
 enum FeedbackStatus {
@@ -142,6 +175,54 @@ enum SupportPriority {
   MEDIUM
   HIGH
   URGENT
+}
+
+// Cancellation reasons for Consultations and Subscriptions
+enum CancellationReason {
+  // User-initiated
+  SCHEDULE_CONFLICT
+  FOUND_ALTERNATIVE
+  FINANCIAL_REASONS
+  PERSONAL_EMERGENCY
+  NO_LONGER_NEEDED
+
+  // Consultant-initiated
+  CONSULTANT_UNAVAILABLE
+  CONSULTANT_EMERGENCY
+
+  // System-initiated
+  PAYMENT_FAILED
+  EXPIRED
+
+  // Issue-related
+  CONSULTANT_ISSUE
+  TECHNICAL_ISSUE
+
+  // Other
+  OTHER
+}
+
+// Issue types for support tickets (Swiggy-style categorization)
+enum SupportIssueType {
+  // Booking Issues
+  CONSULTANT_NO_SHOW
+  SESSION_QUALITY_POOR
+  TECHNICAL_ISSUES
+  WRONG_CONSULTANT
+
+  // Payment Issues
+  PAYMENT_FAILED
+  CHARGED_TWICE
+  REFUND_REQUEST
+
+  // Cancellation
+  WANT_TO_CANCEL
+  CANCELLATION_ISSUE
+
+  // General
+  ACCOUNT_ISSUE
+  GENERAL_INQUIRY
+  OTHER
 }
 
 model CookiePreference {
@@ -211,24 +292,24 @@ model VerificationToken {
 //////////////////////////////////////////////////// USER PROFILES and SLOTTING MECHANISM ////////////////////////////////////////////////////
 
 model ConsultantProfile {
-  id             String  @id @default(uuid())
-  description    String? @db.Text
-  experience     Float?
-  rating         Float   @default(0)
+  id          String  @id @default(uuid())
+  description String? @db.Text
+  experience  Float?
+  rating      Float   @default(0)
 
   // New fields for enhanced consultant profile
-  headline              String?       @db.VarChar(120) // Professional headline, max 120 chars
-  websiteUrl            String?
-  twitterUrl            String?
-  githubUrl             String?
-  videoIntroUrl         String?
-  languages             String[]      @default([])
-  toolsAndTechnologies  String[]      @default([])
-  mentoringStyle        String?       @db.Text
-  sessionTypes          SessionType[] @default([])
-  profileCompletionPercentage Int     @default(0)
-  isVerified            Boolean       @default(false)
-  totalMenteesHelped    Int           @default(0)
+  headline                    String?       @db.VarChar(120) // Professional headline, max 120 chars
+  websiteUrl                  String?
+  twitterUrl                  String?
+  githubUrl                   String?
+  videoIntroUrl               String?
+  languages                   String[]      @default([])
+  toolsAndTechnologies        String[]      @default([])
+  mentoringStyle              String?       @db.Text
+  sessionTypes                SessionType[] @default([])
+  profileCompletionPercentage Int           @default(0)
+  isVerified                  Boolean       @default(false)
+  totalMenteesHelped          Int           @default(0)
 
   // Deprecated fields - to be removed in Phase 6
   // @deprecated Use Certification and Education models instead
@@ -259,6 +340,15 @@ model ConsultantProfile {
 
   user   User   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId String @unique
+
+  // Payout relations
+  earnings       ConsultantEarnings[]
+  payouts        Payout[]
+  payoutAccounts PayoutAccount[]
+
+  // Cached balances (in smallest currency unit, e.g., paise)
+  totalRevenue   Int @default(0)
+  pendingRevenue Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -381,9 +471,9 @@ model StaffProfile {
   // New fields for enhanced staff profile
   employeeId   String?
   hireDate     DateTime?
-  reportsTo    String?   // Manager's user ID
+  reportsTo    String? // Manager's user ID
   skills       String[]  @default([])
-  workSchedule String?   // e.g., "9 AM - 5 PM", "Shift A", etc.
+  workSchedule String? // e.g., "9 AM - 5 PM", "Shift A", etc.
 
   user   User   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId String @unique
@@ -399,7 +489,7 @@ model StaffProfile {
 model AdminProfile {
   id              String     @id @default(uuid())
   adminLevel      AdminLevel
-  accessScope     Json?      // Granular permissions JSON
+  accessScope     Json? // Granular permissions JSON
   assignedRegions String[]   @default([]) // Geographic or domain regions
   notes           String?    @db.Text
 
@@ -552,6 +642,12 @@ model Consultation {
   feedbackFromConsultant String?
   rating                 Float?
 
+  // Cancellation tracking
+  cancellationReason CancellationReason?
+  cancellationNotes  String?             @db.Text
+  cancelledAt        DateTime?           @db.Timestamptz()
+  cancelledBy        String? // userId who cancelled
+
   appointment Appointment?
 
   createdAt DateTime @default(now()) @db.Timestamptz()
@@ -567,7 +663,7 @@ model SubscriptionPlan {
   priceCurrency          String           @default("INR")
   callsPerWeek           Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
-  totalSessions          Int              @default(4)   // callsPerWeek × durationInMonths × 4
+  totalSessions          Int              @default(4) // callsPerWeek × durationInMonths × 4
   totalHours             Float            @default(4.0) // totalSessions × sessionDurationInHours
   emailSupport           PlanEmailSupport @default(GENERAL)
   language               String           @default("English")
@@ -601,6 +697,12 @@ model Subscription {
   feedbackFromConsultee  String?
   feedbackFromConsultant String?
   rating                 Float?
+
+  // Cancellation tracking
+  cancellationReason CancellationReason?
+  cancellationNotes  String?             @db.Text
+  cancelledAt        DateTime?           @db.Timestamptz()
+  cancelledBy        String? // userId who cancelled
 
   subscriptionPlan   SubscriptionPlan @relation(fields: [subscriptionPlanId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   subscriptionPlanId String
@@ -688,7 +790,7 @@ model ClassPlan {
   durationInMonths       Int              @default(1) // Duration in months
   meetingsPerWeek        Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
-  totalSessions          Int              @default(4)   // meetingsPerWeek × durationInMonths × 4
+  totalSessions          Int              @default(4) // meetingsPerWeek × durationInMonths × 4
   totalHours             Float            @default(4.0) // totalSessions × sessionDurationInHours
   emailSupport           PlanEmailSupport @default(GENERAL)
   maxParticipants        Int              @default(1)
@@ -946,15 +1048,19 @@ model Payment {
   discountCode   DiscountCode? @relation(fields: [discountCodeId], references: [id], onUpdate: Cascade, onDelete: SetNull)
   discountCodeId String?
 
-  refunds  Refund[]  // Refunds associated with this payment
+  refunds  Refund[] // Refunds associated with this payment
   disputes Dispute[] // Disputes associated with this payment
+
+  // Payout relations
+  earnings ConsultantEarnings?
+  invoice  Invoice?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([userId, appointmentId]) // Allow multiple users to pay for same appointment (webinars/classes)
   @@index([expiresAt, paymentStatus])
   @@index([isMockPayment])
-  @@unique([userId, appointmentId]) // Allow multiple users to pay for same appointment (webinars/classes)
 }
 
 enum PaymentGateway {
@@ -973,13 +1079,13 @@ enum PaymentStatus {
 
 model Refund {
   id             String         @id @default(uuid())
-  amount         Int            // Amount refunded in smallest currency unit (e.g., cents for USD)
+  amount         Int // Amount refunded in smallest currency unit (e.g., cents for USD)
   currency       String
-  reason         String?        // Reason for refund
+  reason         String? // Reason for refund
   status         RefundStatus
   refundId       String         @unique // Gateway-specific refund ID (Stripe/Razorpay)
   paymentGateway PaymentGateway
-  metadata       Json?          // Additional gateway-specific metadata
+  metadata       Json? // Additional gateway-specific metadata
 
   payment   Payment @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   paymentId String
@@ -993,23 +1099,23 @@ model Refund {
 }
 
 enum RefundStatus {
-  PENDING    // Refund initiated but not yet processed
-  SUCCEEDED  // Refund completed successfully
-  FAILED     // Refund failed
-  CANCELLED  // Refund cancelled
+  PENDING // Refund initiated but not yet processed
+  SUCCEEDED // Refund completed successfully
+  FAILED // Refund failed
+  CANCELLED // Refund cancelled
 }
 
 model Dispute {
-  id             String         @id @default(uuid())
-  amount         Int            // Disputed amount in smallest currency unit
-  currency       String
-  reason         String         // Dispute reason from gateway
-  status         DisputeStatus
-  disputeId      String         @unique // Gateway-specific dispute ID
-  paymentGateway PaymentGateway
-  evidence       Json?          // Evidence submitted to gateway
-  dueBy          DateTime?      // Deadline to respond to dispute
-  isChargeRefundable Boolean    @default(true)
+  id                 String         @id @default(uuid())
+  amount             Int // Disputed amount in smallest currency unit
+  currency           String
+  reason             String // Dispute reason from gateway
+  status             DisputeStatus
+  disputeId          String         @unique // Gateway-specific dispute ID
+  paymentGateway     PaymentGateway
+  evidence           Json? // Evidence submitted to gateway
+  dueBy              DateTime? // Deadline to respond to dispute
+  isChargeRefundable Boolean        @default(true)
 
   payment   Payment @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   paymentId String
@@ -1024,14 +1130,183 @@ model Dispute {
 }
 
 enum DisputeStatus {
-  WARNING_NEEDS_RESPONSE   // Early fraud warning, needs response
-  WARNING_UNDER_REVIEW     // Early fraud warning under review
-  WARNING_CLOSED           // Early fraud warning closed
-  NEEDS_RESPONSE           // Dispute filed, needs evidence
-  UNDER_REVIEW             // Evidence submitted, under review
-  CHARGE_REFUNDED          // Charge was refunded
-  WON                      // Dispute won
-  LOST                     // Dispute lost
+  WARNING_NEEDS_RESPONSE // Early fraud warning, needs response
+  WARNING_UNDER_REVIEW // Early fraud warning under review
+  WARNING_CLOSED // Early fraud warning closed
+  NEEDS_RESPONSE // Dispute filed, needs evidence
+  UNDER_REVIEW // Evidence submitted, under review
+  CHARGE_REFUNDED // Charge was refunded
+  WON // Dispute won
+  LOST // Dispute lost
+}
+
+////////////////////////////////////////////// PAYOUT SYSTEM ////////////////////////////////////////////////////
+
+enum EarningStatus {
+  PENDING // In hold period
+  HELD // Extended hold (dispute)
+  READY // Ready for payout
+  PAID // Successfully paid
+  REFUNDED // Refunded to consultee
+}
+
+enum PayoutStatus {
+  PENDING // Awaiting approval
+  APPROVED // Admin approved
+  PROCESSING // Being processed
+  COMPLETED // Successfully sent
+  FAILED // Provider rejected
+  CANCELLED // Manually cancelled
+}
+
+enum PayoutMethod {
+  BANK_TRANSFER
+  UPI
+  STRIPE_TRANSFER
+}
+
+enum PayoutAccountType {
+  BANK_ACCOUNT
+  UPI
+  STRIPE_CONNECT
+}
+
+model ConsultantEarnings {
+  id                  String  @id @default(cuid())
+  consultantProfileId String
+  paymentId           String  @unique
+  payoutId            String?
+
+  // Revenue breakdown
+  grossAmount     Int // Total sale price
+  platformFee     Int // Platform cut (20%)
+  consultantShare Int // Consultant cut (80%)
+
+  // Status tracking
+  status    EarningStatus @default(PENDING)
+  holdUntil DateTime // Release after hold period
+  paidAt    DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  consultantProfile ConsultantProfile @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  payment           Payment           @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  payout            Payout?           @relation(fields: [payoutId], references: [id])
+
+  @@index([consultantProfileId, status])
+  @@index([status, holdUntil])
+  @@index([payoutId])
+}
+
+model Payout {
+  id                  String         @id @default(cuid())
+  consultantProfileId String
+  provider            PaymentGateway
+  providerPayoutId    String?        @unique
+  amount              Int
+  currency            String         @default("INR")
+  status              PayoutStatus   @default(PENDING)
+  method              PayoutMethod
+  batchId             String?
+
+  // Processing
+  failureReason String?
+  retryCount    Int       @default(0)
+  processedAt   DateTime?
+  approvedAt    DateTime?
+  approvedBy    String?
+
+  // Idempotency (required by Razorpay from March 2025)
+  idempotencyKey String? @unique
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  consultantProfile ConsultantProfile    @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  earnings          ConsultantEarnings[]
+
+  @@index([consultantProfileId, status])
+  @@index([batchId])
+  @@index([status])
+}
+
+model PayoutAccount {
+  id                  String            @id @default(cuid())
+  consultantProfileId String
+  provider            PaymentGateway
+  accountType         PayoutAccountType @default(BANK_ACCOUNT)
+
+  // Bank details (store only masked, full via gateway)
+  accountHolderName  String?
+  bankName           String?
+  accountNumberLast4 String? // Only last 4 digits
+  ifscCode           String?
+
+  // UPI
+  upiId String?
+
+  // Gateway IDs
+  stripeAccountId     String? @unique
+  stripeAccountStatus String?
+  razorpayContactId   String?
+  razorpayFundAccId   String? @unique
+
+  // Verification
+  isVerified Boolean @default(false)
+  isDefault  Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  consultantProfile ConsultantProfile @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@index([consultantProfileId])
+  @@index([isDefault])
+}
+
+model Invoice {
+  id            String        @id @default(cuid())
+  paymentId     String?       @unique
+  invoiceNumber String        @unique // INV-YYYYMM-XXXXX
+  amount        Int
+  currency      String        @default("INR")
+  status        PaymentStatus @default(PENDING)
+  items         Json // Line items with HSN codes
+  pdfUrl        String?
+  dueDate       DateTime?
+  paidAt        DateTime?
+
+  // Tax breakdown
+  taxAmount Int? // GST amount in paise
+  taxRate   Float? // 18% for services
+  hsnCode   String? // SAC code (999293 for consulting)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  payment Payment? @relation(fields: [paymentId], references: [id])
+
+  @@index([invoiceNumber])
+  @@index([status])
+  @@index([paymentId])
+}
+
+model WebhookEvent {
+  id          String    @id @default(cuid())
+  provider    String // razorpay, stripe, etc.
+  eventId     String    @unique
+  eventType   String
+  payload     Json
+  signature   String?
+  processed   Boolean   @default(false)
+  processedAt DateTime?
+  error       String?
+  receivedAt  DateTime  @default(now())
+
+  @@index([provider])
+  @@index([processed])
+  @@index([eventType])
 }
 
 model DiscountCode {
@@ -1040,6 +1315,11 @@ model DiscountCode {
   description   String
   discountType  DiscountType
   discountValue Float
+  isActive      Boolean      @default(true)
+  expiresAt     DateTime?
+  maxUses       Int?
+  currentUses   Int          @default(0)
+  maxDiscount   Float?
 
   Payment Payment[]
 
@@ -1101,27 +1381,27 @@ enum Gender {
 
 enum CareerStage {
   STUDENT
-  EARLY_CAREER   // 0-3 years experience
-  MID_CAREER     // 3-10 years experience
-  SENIOR         // 10+ years experience
-  EXECUTIVE      // C-level or equivalent
+  EARLY_CAREER // 0-3 years experience
+  MID_CAREER // 3-10 years experience
+  SENIOR // 10+ years experience
+  EXECUTIVE // C-level or equivalent
 }
 
 enum AdminLevel {
-  SUPER_ADMIN    // Full system access
-  ADMIN          // High-level management
-  MODERATOR      // Day-to-day operations
+  SUPER_ADMIN // Full system access
+  ADMIN // High-level management
+  MODERATOR // Day-to-day operations
 }
 
 enum BudgetPreference {
-  BUDGET         // Looking for affordable options
-  MODERATE       // Mid-range pricing
-  PREMIUM        // Willing to pay for premium
-  FLEXIBLE       // No specific preference
+  BUDGET // Looking for affordable options
+  MODERATE // Mid-range pricing
+  PREMIUM // Willing to pay for premium
+  FLEXIBLE // No specific preference
 }
 
 enum SessionType {
-  ONE_ON_ONE     // 1:1 video/audio sessions
-  GROUP          // Group sessions
-  ASYNC_REVIEW   // Asynchronous document/code review
+  ONE_ON_ONE // 1:1 video/audio sessions
+  GROUP // Group sessions
+  ASYNC_REVIEW // Asynchronous document/code review
 }

--- a/backend/routes/api/checkout/index.dart
+++ b/backend/routes/api/checkout/index.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:backend/database/database_client.dart';
 import 'package:backend/database/repositories/appointment_repository.dart';
 import 'package:backend/services/razorpay_service.dart';
+import 'package:backend/services/stripe_service.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
@@ -368,6 +369,7 @@ Future<Response> _handleCreateCheckout(RequestContext context) async {
     // Generate gateway-specific fields
     String? razorpayOrderId;
     String? stripeClientSecret;
+    String? stripePaymentIntentId;
 
     if (paymentGateway.toUpperCase() == 'RAZORPAY') {
       // Create a real Razorpay order via API
@@ -436,9 +438,82 @@ Future<Response> _handleCreateCheckout(RequestContext context) async {
           },
         );
       }
-    } else {
-      // For Stripe, return client secret
-      stripeClientSecret = paymentInfo['paymentIntent'] as String?;
+    } else if (paymentGateway.toUpperCase() == 'STRIPE') {
+      // Create a real Stripe PaymentIntent
+      final env = DotEnv(includePlatformEnvironment: true)..load();
+      final stripeSecretKey = env['STRIPE_SECRET_KEY'];
+
+      if (stripeSecretKey == null || stripeSecretKey.isEmpty) {
+        SentryLogger.error(
+          'Stripe credentials not configured',
+          context: 'CheckoutRoute',
+        );
+        return Response.json(
+          statusCode: HttpStatus.internalServerError,
+          body: {
+            'error': {
+              'code': 'STRIPE_NOT_CONFIGURED',
+              'message': 'Payment gateway not configured',
+              'hint': 'Add STRIPE_SECRET_KEY to .env',
+            },
+          },
+        );
+      }
+
+      try {
+        final stripeService = StripeService(secretKey: stripeSecretKey);
+
+        final amountInSmallestUnit = (amount * 100).round();
+        final paymentIdStr = paymentInfo['paymentId'] as String;
+
+        final paymentIntent = await stripeService.createPaymentIntent(
+          amountInSmallestUnit: amountInSmallestUnit,
+          currency: currency,
+          metadata: {
+            'payment_id': paymentIdStr,
+            'booking_id': finalBookingId,
+            'user_id': userId,
+          },
+        );
+
+        stripeClientSecret = paymentIntent.clientSecret;
+        stripePaymentIntentId = paymentIntent.id;
+
+        // Update payment record with Stripe payment intent ID
+        // We need to update the paymentIntent field to store the Stripe pi_ ID
+        final updateQuery = JsonQueryBuilder()
+            .model('Payment')
+            .action(QueryAction.update)
+            .where({'id': paymentIdStr}).data({
+          'paymentIntent': paymentIntent.id,
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        }).build();
+        await db.executor.executeMutation(updateQuery);
+
+        SentryLogger.info(
+          'Created Stripe PaymentIntent: ${paymentIntent.id} '
+          'for amount: $amountInSmallestUnit $currency',
+          context: 'CheckoutRoute',
+        );
+      } on StripeException catch (e, stackTrace) {
+        await SentryLogger.error(
+          'Failed to create Stripe PaymentIntent',
+          context: 'CheckoutRoute',
+          error: e,
+          stackTrace: stackTrace,
+        );
+
+        return Response.json(
+          statusCode: HttpStatus.badGateway,
+          body: {
+            'error': {
+              'code': 'STRIPE_PAYMENT_FAILED',
+              'message': 'Failed to create payment intent',
+              'details': e.message,
+            },
+          },
+        );
+      }
     }
 
     return Response.json(
@@ -451,6 +526,8 @@ Future<Response> _handleCreateCheckout(RequestContext context) async {
         if (razorpayOrderId != null) 'razorpayOrderId': razorpayOrderId,
         if (stripeClientSecret != null)
           'stripeClientSecret': stripeClientSecret,
+        if (stripePaymentIntentId != null)
+          'stripePaymentIntentId': stripePaymentIntentId,
         if (discountAmount != null) 'discountAmount': discountAmount,
         if (discountCode != null) 'discountCode': discountCode,
         'bookingId': finalBookingId,

--- a/backend/routes/api/payments/[paymentId]/disputes.dart
+++ b/backend/routes/api/payments/[paymentId]/disputes.dart
@@ -1,0 +1,90 @@
+import 'dart:io' as io;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// Dispute visibility endpoint
+///
+/// GET /api/payments/:paymentId/disputes
+///
+/// Returns all disputes associated with a payment.
+/// User must be authenticated and own the payment.
+Future<Response> onRequest(RequestContext context, String paymentId) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: io.HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    // Verify authentication
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    // Verify user owns this payment
+    final payment = await db.checkout.getPaymentById(paymentId);
+    if (payment == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.notFound,
+        body: {'error': {'message': 'Payment not found'}},
+      );
+    }
+
+    if (payment['userId'] != userId) {
+      return Response.json(
+        statusCode: io.HttpStatus.forbidden,
+        body: {'error': {'message': 'Access denied'}},
+      );
+    }
+
+    // Get disputes for this payment
+    final disputes = await db.disputes.getDisputesByPaymentId(paymentId);
+
+    // Format response
+    final formattedDisputes = disputes.map((d) => {
+          'id': d['id'],
+          'disputeId': d['disputeId'],
+          'amount': d['amount'],
+          'currency': d['currency'],
+          'reason': d['reason'],
+          'status': d['status'],
+          'paymentGateway': d['paymentGateway'],
+          'dueBy': d['dueBy'],
+          'isChargeRefundable': d['isChargeRefundable'],
+          'createdAt': d['createdAt'],
+        }).toList();
+
+    return Response.json(
+      body: serializeForJson({
+        'paymentId': paymentId,
+        'disputes': formattedDisputes,
+        'count': formattedDisputes.length,
+      },),
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.error(
+      'Error fetching disputes for payment: $paymentId',
+      context: 'DisputesRoute',
+      error: e,
+      stackTrace: stackTrace,
+    );
+
+    return Response.json(
+      statusCode: io.HttpStatus.internalServerError,
+      body: {
+        'error': {
+          'message': 'Failed to fetch disputes',
+          'details': e.toString(),
+        },
+      },
+    );
+  }
+}

--- a/backend/routes/api/payments/[paymentId]/refunds.dart
+++ b/backend/routes/api/payments/[paymentId]/refunds.dart
@@ -1,0 +1,88 @@
+import 'dart:io' as io;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// Refund visibility endpoint
+///
+/// GET /api/payments/:paymentId/refunds
+///
+/// Returns all refunds associated with a payment.
+/// User must be authenticated and own the payment.
+Future<Response> onRequest(RequestContext context, String paymentId) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: io.HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    // Verify authentication
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    // Verify user owns this payment
+    final payment = await db.checkout.getPaymentById(paymentId);
+    if (payment == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.notFound,
+        body: {'error': {'message': 'Payment not found'}},
+      );
+    }
+
+    if (payment['userId'] != userId) {
+      return Response.json(
+        statusCode: io.HttpStatus.forbidden,
+        body: {'error': {'message': 'Access denied'}},
+      );
+    }
+
+    // Get refunds for this payment
+    final refunds = await db.refunds.getRefundsByPaymentId(paymentId);
+
+    // Format response
+    final formattedRefunds = refunds.map((r) => {
+      'id': r['id'],
+      'refundId': r['refundId'],
+      'amount': r['amount'],
+      'currency': r['currency'],
+      'status': r['status'],
+      'reason': r['reason'],
+      'paymentGateway': r['paymentGateway'],
+      'createdAt': r['createdAt'],
+    }).toList();
+
+    return Response.json(
+      body: serializeForJson({
+        'paymentId': paymentId,
+        'refunds': formattedRefunds,
+        'count': formattedRefunds.length,
+      }),
+    );
+  } catch (e, stackTrace) {
+    SentryLogger.error(
+      'Error fetching refunds for payment: $paymentId',
+      context: 'RefundsRoute',
+      error: e,
+      stackTrace: stackTrace,
+    );
+
+    return Response.json(
+      statusCode: io.HttpStatus.internalServerError,
+      body: {
+        'error': {
+          'message': 'Failed to fetch refunds',
+          'details': e.toString(),
+        },
+      },
+    );
+  }
+}

--- a/backend/routes/api/webhooks/razorpay.dart
+++ b/backend/routes/api/webhooks/razorpay.dart
@@ -143,28 +143,27 @@ Future<Response> onRequest(RequestContext context) async {
 
         case 'payment.dispute.created':
           // Handle dispute creation
-          if (paymentEntity != null) {
-            final disputeData =
-                paymentEntity['dispute'] as Map<String, dynamic>?;
-            final orderId = paymentEntity['order_id'] as String?;
+          // Note: Razorpay sends dispute at payload.dispute.entity (sibling to payment)
+          final disputeEntity =
+              payload['payload']?['dispute']?['entity'] as Map<String, dynamic>?;
+          final disputeOrderId = paymentEntity?['order_id'] as String?;
 
-            if (disputeData != null && orderId != null) {
-              await handlers.handleDisputeCreated(
-                paymentIntentOrOrderId: orderId,
-                disputeId: disputeData['id'] as String,
-                amount: disputeData['amount'] as int? ?? 0,
-                currency: disputeData['currency'] as String? ?? 'INR',
-                reason: disputeData['reason_code'] as String? ?? 'unknown',
-                status: _mapDisputeStatus(disputeData['status'] as String?),
-                gateway: 'RAZORPAY',
-                dueBy: disputeData['respond_by'] != null
-                    ? DateTime.fromMillisecondsSinceEpoch(
-                        (disputeData['respond_by'] as int) * 1000,
-                      )
-                    : null,
-              );
-              success = true;
-            }
+          if (disputeEntity != null && disputeOrderId != null) {
+            await handlers.handleDisputeCreated(
+              paymentIntentOrOrderId: disputeOrderId,
+              disputeId: disputeEntity['id'] as String,
+              amount: disputeEntity['amount'] as int? ?? 0,
+              currency: disputeEntity['currency'] as String? ?? 'INR',
+              reason: disputeEntity['reason_code'] as String? ?? 'unknown',
+              status: _mapDisputeStatus(disputeEntity['status'] as String?),
+              gateway: 'RAZORPAY',
+              dueBy: disputeEntity['respond_by'] != null
+                  ? DateTime.fromMillisecondsSinceEpoch(
+                      (disputeEntity['respond_by'] as int) * 1000,
+                    )
+                  : null,
+            );
+            success = true;
           }
 
         default:

--- a/backend/routes/api/webhooks/razorpay.dart
+++ b/backend/routes/api/webhooks/razorpay.dart
@@ -13,8 +13,11 @@ import 'package:dart_frog/dart_frog.dart';
 ///
 /// Handles webhook events from Razorpay:
 /// - payment.captured: Payment successful
+/// - order.paid: Order paid
 /// - payment.failed: Payment failed
 /// - refund.processed: Refund completed
+/// - refund.created: Refund initiated
+/// - payment.dispute.created: Dispute created
 Future<Response> onRequest(RequestContext context) async {
   if (context.request.method != HttpMethod.post) {
     return Response(statusCode: io.HttpStatus.methodNotAllowed);
@@ -138,6 +141,32 @@ Future<Response> onRequest(RequestContext context) async {
             }
           }
 
+        case 'payment.dispute.created':
+          // Handle dispute creation
+          if (paymentEntity != null) {
+            final disputeData =
+                paymentEntity['dispute'] as Map<String, dynamic>?;
+            final orderId = paymentEntity['order_id'] as String?;
+
+            if (disputeData != null && orderId != null) {
+              await handlers.handleDisputeCreated(
+                paymentIntentOrOrderId: orderId,
+                disputeId: disputeData['id'] as String,
+                amount: disputeData['amount'] as int? ?? 0,
+                currency: disputeData['currency'] as String? ?? 'INR',
+                reason: disputeData['reason_code'] as String? ?? 'unknown',
+                status: _mapDisputeStatus(disputeData['status'] as String?),
+                gateway: 'RAZORPAY',
+                dueBy: disputeData['respond_by'] != null
+                    ? DateTime.fromMillisecondsSinceEpoch(
+                        (disputeData['respond_by'] as int) * 1000,
+                      )
+                    : null,
+              );
+              success = true;
+            }
+          }
+
         default:
           // Unhandled event type - acknowledge receipt
           SentryLogger.info(
@@ -187,4 +216,22 @@ bool _verifySignature(String body, String? signature, String secret) {
   final expectedSignature = digest.toString();
 
   return signature == expectedSignature;
+}
+
+/// Map Razorpay dispute status to internal status
+String _mapDisputeStatus(String? status) {
+  switch (status) {
+    case 'open':
+      return 'NEEDS_RESPONSE';
+    case 'under_review':
+      return 'UNDER_REVIEW';
+    case 'won':
+      return 'WON';
+    case 'lost':
+      return 'LOST';
+    case 'closed':
+      return 'CHARGE_REFUNDED';
+    default:
+      return 'NEEDS_RESPONSE';
+  }
 }

--- a/backend/routes/api/webhooks/razorpay.dart
+++ b/backend/routes/api/webhooks/razorpay.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/services/webhook_handlers.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// Razorpay webhook endpoint
+///
+/// POST /api/webhooks/razorpay
+///
+/// Handles webhook events from Razorpay:
+/// - payment.captured: Payment successful
+/// - payment.failed: Payment failed
+/// - refund.processed: Refund completed
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: io.HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final db = context.read<DatabaseClient>();
+    final env = io.Platform.environment;
+
+    // Read raw body for signature verification
+    final rawBody = await context.request.body();
+
+    // Verify webhook signature
+    final signature = context.request.headers['x-razorpay-signature'];
+    final webhookSecret = env['RAZORPAY_WEBHOOK_SECRET'];
+
+    if (webhookSecret == null || webhookSecret.isEmpty) {
+      SentryLogger.error(
+        'RAZORPAY_WEBHOOK_SECRET not configured',
+        context: 'RazorpayWebhook',
+      );
+      return Response(statusCode: io.HttpStatus.internalServerError);
+    }
+
+    if (!_verifySignature(rawBody, signature, webhookSecret)) {
+      SentryLogger.warning(
+        'Invalid Razorpay webhook signature',
+        context: 'RazorpayWebhook',
+      );
+      return Response(statusCode: io.HttpStatus.unauthorized);
+    }
+
+    // Parse event payload
+    final payload = jsonDecode(rawBody) as Map<String, dynamic>;
+    final eventType = payload['event'] as String?;
+    final paymentEntity =
+        payload['payload']?['payment']?['entity'] as Map<String, dynamic>?;
+
+    if (eventType == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.badRequest,
+        body: {'error': 'Missing event type'},
+      );
+    }
+
+    // Generate event ID for idempotency
+    // Razorpay events use account_id + event for uniqueness
+    final accountId = payload['account_id'] as String? ?? 'unknown';
+    final paymentId = paymentEntity?['id'] as String? ?? '';
+    final eventId = '${accountId}_${eventType}_$paymentId';
+
+    // Idempotency check - record event
+    final isNew = await db.webhookEvents.recordEvent(
+      eventId: eventId,
+      provider: 'RAZORPAY',
+      eventType: eventType,
+      payload: payload,
+      signature: signature,
+    );
+
+    if (!isNew) {
+      // Already processed by this or web backend
+      return Response.json(body: {'status': 'already_processed'});
+    }
+
+    // Process the event
+    final handlers = WebhookHandlers(db);
+    var success = false;
+
+    try {
+      switch (eventType) {
+        case 'payment.captured':
+        case 'order.paid':
+          final orderId = paymentEntity?['order_id'] as String?;
+          if (orderId != null) {
+            await handlers.handlePaymentSuccess(
+              paymentIntentOrOrderId: orderId,
+              gateway: 'RAZORPAY',
+            );
+            success = true;
+          }
+
+        case 'payment.failed':
+          final orderId = paymentEntity?['order_id'] as String?;
+          final errorDesc =
+              paymentEntity?['error_description'] as String? ?? 'Unknown error';
+          if (orderId != null) {
+            await handlers.handlePaymentFailure(
+              paymentIntentOrOrderId: orderId,
+              gateway: 'RAZORPAY',
+              reason: errorDesc,
+            );
+            success = true;
+          }
+
+        case 'refund.processed':
+        case 'refund.created':
+          final refundEntity =
+              payload['payload']?['refund']?['entity'] as Map<String, dynamic>?;
+          if (refundEntity != null) {
+            final refundId = refundEntity['id'] as String;
+            final refundPaymentId = refundEntity['payment_id'] as String?;
+
+            // Get order ID from the payment
+            String? orderId;
+            if (refundPaymentId != null && paymentEntity != null) {
+              orderId = paymentEntity['order_id'] as String?;
+            }
+
+            if (orderId != null) {
+              await handlers.handleRefundProcessed(
+                refundId: refundId,
+                paymentIntentOrOrderId: orderId,
+                amount: refundEntity['amount'] as int? ?? 0,
+                currency: refundEntity['currency'] as String? ?? 'INR',
+                status: refundEntity['status'] as String? ?? 'processed',
+                gateway: 'RAZORPAY',
+                reason: refundEntity['notes']?['reason'] as String?,
+              );
+              success = true;
+            }
+          }
+
+        default:
+          // Unhandled event type - acknowledge receipt
+          SentryLogger.info(
+            'Unhandled Razorpay event: $eventType',
+            context: 'RazorpayWebhook',
+          );
+          success = true;
+      }
+
+      // Mark event as processed
+      if (success) {
+        await db.webhookEvents.markProcessed(eventId);
+      }
+
+      return Response.json(body: {'status': 'ok'});
+    } catch (e, stackTrace) {
+      // Mark event as failed
+      await db.webhookEvents.markFailed(eventId, e.toString());
+      SentryLogger.error(
+        'Error processing Razorpay webhook: $eventType',
+        context: 'RazorpayWebhook',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Return 200 to prevent Razorpay from retrying - we'll handle retries
+      return Response.json(body: {'status': 'error', 'message': e.toString()});
+    }
+  } catch (e, stackTrace) {
+    SentryLogger.error(
+      'Razorpay webhook error',
+      context: 'RazorpayWebhook',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response(statusCode: io.HttpStatus.internalServerError);
+  }
+}
+
+/// Verify Razorpay webhook signature using HMAC-SHA256
+bool _verifySignature(String body, String? signature, String secret) {
+  if (signature == null || signature.isEmpty) {
+    return false;
+  }
+
+  final hmac = Hmac(sha256, utf8.encode(secret));
+  final digest = hmac.convert(utf8.encode(body));
+  final expectedSignature = digest.toString();
+
+  return signature == expectedSignature;
+}

--- a/backend/routes/api/webhooks/stripe.dart
+++ b/backend/routes/api/webhooks/stripe.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/services/stripe_service.dart';
+import 'package:backend/services/webhook_handlers.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// Stripe webhook endpoint
+///
+/// POST /api/webhooks/stripe
+///
+/// Handles webhook events from Stripe:
+/// - payment_intent.succeeded: Payment successful
+/// - payment_intent.payment_failed: Payment failed
+/// - charge.refunded: Refund completed
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: io.HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final db = context.read<DatabaseClient>();
+    final env = io.Platform.environment;
+
+    // Read raw body for signature verification
+    final rawBody = await context.request.body();
+
+    // Verify webhook signature
+    final signature = context.request.headers['stripe-signature'];
+    final webhookSecret = env['STRIPE_WEBHOOK_SECRET'];
+
+    if (webhookSecret == null || webhookSecret.isEmpty) {
+      SentryLogger.error(
+        'STRIPE_WEBHOOK_SECRET not configured',
+        context: 'StripeWebhook',
+      );
+      return Response(statusCode: io.HttpStatus.internalServerError);
+    }
+
+    // Use StripeService to verify signature
+    final stripeService = StripeService(
+      secretKey: env['STRIPE_SECRET_KEY'] ?? '',
+      webhookSecret: webhookSecret,
+    );
+
+    if (!stripeService.verifyWebhookSignature(
+      payload: rawBody,
+      signature: signature ?? '',
+    )) {
+      SentryLogger.warning(
+        'Invalid Stripe webhook signature',
+        context: 'StripeWebhook',
+      );
+      return Response(statusCode: io.HttpStatus.unauthorized);
+    }
+
+    // Parse event payload
+    final payload = jsonDecode(rawBody) as Map<String, dynamic>;
+    final eventType = payload['type'] as String?;
+    final eventId = payload['id'] as String?;
+    final dataObject = payload['data']?['object'] as Map<String, dynamic>?;
+
+    if (eventType == null || eventId == null) {
+      return Response.json(
+        statusCode: io.HttpStatus.badRequest,
+        body: {'error': 'Missing event type or id'},
+      );
+    }
+
+    // Idempotency check - record event
+    final isNew = await db.webhookEvents.recordEvent(
+      eventId: eventId,
+      provider: 'STRIPE',
+      eventType: eventType,
+      payload: payload,
+      signature: signature,
+    );
+
+    if (!isNew) {
+      // Already processed by this or web backend
+      return Response.json(body: {'status': 'already_processed'});
+    }
+
+    // Process the event
+    final handlers = WebhookHandlers(db);
+    var success = false;
+
+    try {
+      switch (eventType) {
+        case 'payment_intent.succeeded':
+          final paymentIntentId = dataObject?['id'] as String?;
+          if (paymentIntentId != null) {
+            await handlers.handlePaymentSuccess(
+              paymentIntentOrOrderId: paymentIntentId,
+              gateway: 'STRIPE',
+            );
+            success = true;
+          }
+
+        case 'payment_intent.payment_failed':
+          final paymentIntentId = dataObject?['id'] as String?;
+          final lastError = dataObject?['last_payment_error'] as Map?;
+          final errorMessage = lastError?['message'] as String? ?? 'Unknown';
+          if (paymentIntentId != null) {
+            await handlers.handlePaymentFailure(
+              paymentIntentOrOrderId: paymentIntentId,
+              gateway: 'STRIPE',
+              reason: errorMessage,
+            );
+            success = true;
+          }
+
+        case 'charge.refunded':
+          // Extract refund from the charge
+          final refunds = dataObject?['refunds']?['data'] as List?;
+          final paymentIntentId = dataObject?['payment_intent'] as String?;
+
+          if (refunds != null &&
+              refunds.isNotEmpty &&
+              paymentIntentId != null) {
+            // Process the most recent refund
+            final refund = refunds.first as Map<String, dynamic>;
+            await handlers.handleRefundProcessed(
+              refundId: refund['id'] as String,
+              paymentIntentOrOrderId: paymentIntentId,
+              amount: refund['amount'] as int? ?? 0,
+              currency: refund['currency'] as String? ?? 'usd',
+              status: refund['status'] as String? ?? 'succeeded',
+              gateway: 'STRIPE',
+              reason: refund['reason'] as String?,
+            );
+            success = true;
+          }
+
+        default:
+          // Unhandled event type - acknowledge receipt
+          SentryLogger.info(
+            'Unhandled Stripe event: $eventType',
+            context: 'StripeWebhook',
+          );
+          success = true;
+      }
+
+      // Mark event as processed
+      if (success) {
+        await db.webhookEvents.markProcessed(eventId);
+      }
+
+      return Response.json(body: {'status': 'ok'});
+    } catch (e, stackTrace) {
+      // Mark event as failed
+      await db.webhookEvents.markFailed(eventId, e.toString());
+      SentryLogger.error(
+        'Error processing Stripe webhook: $eventType',
+        context: 'StripeWebhook',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Return 200 to prevent Stripe from retrying - we'll handle retries
+      return Response.json(body: {'status': 'error', 'message': e.toString()});
+    }
+  } catch (e, stackTrace) {
+    SentryLogger.error(
+      'Stripe webhook error',
+      context: 'StripeWebhook',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response(statusCode: io.HttpStatus.internalServerError);
+  }
+}

--- a/backend/routes/api/webhooks/stripe.dart
+++ b/backend/routes/api/webhooks/stripe.dart
@@ -15,6 +15,7 @@ import 'package:dart_frog/dart_frog.dart';
 /// - payment_intent.succeeded: Payment successful
 /// - payment_intent.payment_failed: Payment failed
 /// - charge.refunded: Refund completed
+/// - charge.dispute.created: Dispute created
 Future<Response> onRequest(RequestContext context) async {
   if (context.request.method != HttpMethod.post) {
     return Response(statusCode: io.HttpStatus.methodNotAllowed);
@@ -134,6 +135,34 @@ Future<Response> onRequest(RequestContext context) async {
             success = true;
           }
 
+        case 'charge.dispute.created':
+          // Handle dispute creation
+          final disputePaymentIntentId =
+              dataObject?['payment_intent'] as String?;
+          final evidenceDetails =
+              dataObject?['evidence_details'] as Map<String, dynamic>?;
+
+          if (disputePaymentIntentId != null) {
+            await handlers.handleDisputeCreated(
+              paymentIntentOrOrderId: disputePaymentIntentId,
+              disputeId: dataObject?['id'] as String? ?? '',
+              amount: dataObject?['amount'] as int? ?? 0,
+              currency:
+                  (dataObject?['currency'] as String?)?.toUpperCase() ?? 'USD',
+              reason: dataObject?['reason'] as String? ?? 'unknown',
+              status: _mapDisputeStatus(dataObject?['status'] as String?),
+              gateway: 'STRIPE',
+              dueBy: evidenceDetails?['due_by'] != null
+                  ? DateTime.fromMillisecondsSinceEpoch(
+                      (evidenceDetails!['due_by'] as int) * 1000,
+                    )
+                  : null,
+              isChargeRefundable:
+                  dataObject?['is_charge_refundable'] as bool? ?? true,
+            );
+            success = true;
+          }
+
         default:
           // Unhandled event type - acknowledge receipt
           SentryLogger.info(
@@ -169,5 +198,25 @@ Future<Response> onRequest(RequestContext context) async {
       stackTrace: stackTrace,
     );
     return Response(statusCode: io.HttpStatus.internalServerError);
+  }
+}
+
+/// Map Stripe dispute status to internal status
+String _mapDisputeStatus(String? status) {
+  switch (status) {
+    case 'warning_needs_response':
+    case 'needs_response':
+      return 'NEEDS_RESPONSE';
+    case 'warning_under_review':
+    case 'under_review':
+      return 'UNDER_REVIEW';
+    case 'charge_refunded':
+      return 'CHARGE_REFUNDED';
+    case 'won':
+      return 'WON';
+    case 'lost':
+      return 'LOST';
+    default:
+      return 'NEEDS_RESPONSE';
   }
 }


### PR DESCRIPTION
## Summary

Implements **GitHub Issue #13** - Webhook redundancy and Stripe support for shared database architecture, plus complete dispute handling.

### Core Features
- ✅ Razorpay webhook: `payment.captured`, `payment.failed`, `refund.processed`, `payment.dispute.created`
- ✅ Stripe webhook: `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.refunded`, `charge.dispute.created`
- ✅ Stripe PaymentIntent creation in checkout route
- ✅ Idempotent webhook processing via WebhookEvent repository
- ✅ Refund visibility endpoint for mobile users
- ✅ Dispute visibility endpoint for mobile users
- ✅ Prisma schema synced with web app

## Problem Solved

The mobile and web backends share the same database but run as separate servers. Previously:
- If user closed app before calling `/verify`, payment could be lost
- If web backend was down, webhooks would fail
- International users couldn't pay (no Stripe support)
- No dispute visibility for mobile users

Now both backends can receive webhooks, and the first to process wins via idempotency.

## Files Changed

| File | Purpose |
|------|---------|
| `prisma/schema.prisma` | Synced with web app (WebhookEvent, Dispute models) |
| `webhook_event_repository.dart` | Idempotent event tracking |
| `refund_repository.dart` | Refund CRUD operations |
| `dispute_repository.dart` | Dispute CRUD operations |
| `stripe_service.dart` | Stripe API client |
| `webhook_handlers.dart` | Shared payment/refund/dispute business logic |
| `routes/api/webhooks/razorpay.dart` | Razorpay webhook endpoint |
| `routes/api/webhooks/stripe.dart` | Stripe webhook endpoint |
| `routes/api/payments/[paymentId]/refunds.dart` | Refund visibility |
| `routes/api/payments/[paymentId]/disputes.dart` | Dispute visibility |

## New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/webhooks/razorpay` | POST | Razorpay webhook handler |
| `/api/webhooks/stripe` | POST | Stripe webhook handler |
| `/api/payments/:paymentId/refunds` | GET | Get refunds for a payment |
| `/api/payments/:paymentId/disputes` | GET | Get disputes for a payment |

## Webhook Events Handled

| Gateway | Event | Handler |
|---------|-------|---------|
| Razorpay | `payment.captured` | Updates payment status, confirms booking |
| Razorpay | `order.paid` | Updates payment status, confirms booking |
| Razorpay | `payment.failed` | Updates payment status to FAILED |
| Razorpay | `refund.processed` | Creates refund record |
| Razorpay | `payment.dispute.created` | Creates dispute record |
| Stripe | `payment_intent.succeeded` | Updates payment status, confirms booking |
| Stripe | `payment_intent.payment_failed` | Updates payment status to FAILED |
| Stripe | `charge.refunded` | Creates refund record |
| Stripe | `charge.dispute.created` | Creates dispute record |

## Configuration Required (Post-Merge)

Add to `.env`:
```
STRIPE_SECRET_KEY=sk_xxx
STRIPE_WEBHOOK_SECRET=whsec_xxx
RAZORPAY_WEBHOOK_SECRET=xxx
```

Configure webhooks in payment dashboards to send to:
- Razorpay: `https://mobile-api.familiarise.com/api/webhooks/razorpay`
- Stripe: `https://mobile-api.familiarise.com/api/webhooks/stripe`

## Test plan

- [ ] Test Razorpay payment flow with webhook
- [ ] Test Stripe payment flow with webhook
- [ ] Verify idempotency (same webhook twice should not double-process)
- [ ] Test refund visibility endpoint
- [ ] Test dispute visibility endpoint
- [ ] Test with Stripe CLI: `stripe listen --forward-to localhost:8080/api/webhooks/stripe`
- [ ] Test with Razorpay webhook simulator

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)