### PR TITLE
fix: align signup hooks with web + dedup auth remote sources

### DIFF
--- a/backend/lib/database/repositories/user_repository.dart
+++ b/backend/lib/database/repositories/user_repository.dart
@@ -186,6 +186,58 @@ class UserRepository extends BaseRepository {
     return executeQueryAsSingleMap(query, txn: txn);
   }
 
+  /// Create default CookiePreference and NotificationPreference for a user.
+  ///
+  /// Matches the web app's BetterAuth databaseHooks.user.create behavior.
+  /// Should be called within the signup transaction for data consistency.
+  Future<void> createDefaultPreferences(
+    String userId, {
+    TransactionExecutor? txn,
+  }) async {
+    final now = nowIso8601;
+
+    // Create CookiePreference with defaults (essential: true, rest: false)
+    final cookieQuery = JsonQueryBuilder()
+        .model('cookie_preferences')
+        .action(QueryAction.create)
+        .data({
+      'userId': userId,
+      'essential': true,
+      'analytics': false,
+      'marketing': false,
+      'functional': false,
+      'consentGivenAt': now,
+      'consentUpdatedAt': now,
+    }).build();
+
+    await executeMutation(cookieQuery, txn: txn);
+
+    // Create NotificationPreference with defaults
+    final notifQuery = JsonQueryBuilder()
+        .model('notification_preferences')
+        .action(QueryAction.create)
+        .data({
+      'userId': userId,
+      'allNotifications': true,
+      'inAppEnabled': true,
+      'emailEnabled': true,
+      'pushEnabled': false,
+      'mentions': false,
+      'directMessages': false,
+      'updates': false,
+      'appointmentReminders': true,
+      'paymentNotifications': true,
+      'supportUpdates': true,
+      'feedbackAlerts': true,
+      'trialNotifications': true,
+      'subscriptionAlerts': true,
+      'marketingEmails': false,
+      'quietHoursEnabled': false,
+    }).build();
+
+    await executeMutation(notifQuery, txn: txn);
+  }
+
   /// Delete a user by ID (for cleanup on failed registration)
   Future<void> delete(String id) async {
     final query = JsonQueryBuilder()

--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -125,8 +125,8 @@ SchemaRegistry buildSchemaRegistry() {
       'role': const FieldInfo(name: 'role', columnName: 'role', type: 'String'),
       'dateOfBirth': const FieldInfo(
           name: 'dateOfBirth', columnName: 'dateOfBirth', type: 'DateTime'),
-      'gender': const FieldInfo(
-          name: 'gender', columnName: 'gender', type: 'String'),
+      'gender':
+          const FieldInfo(name: 'gender', columnName: 'gender', type: 'String'),
       'city': const FieldInfo(name: 'city', columnName: 'city', type: 'String'),
       'country': const FieldInfo(
           name: 'country', columnName: 'country', type: 'String'),
@@ -302,15 +302,11 @@ SchemaRegistry buildSchemaRegistry() {
       'careerStage': const FieldInfo(
           name: 'careerStage', columnName: 'careerStage', type: 'String'),
       'currentCompany': const FieldInfo(
-          name: 'currentCompany',
-          columnName: 'currentCompany',
-          type: 'String'),
+          name: 'currentCompany', columnName: 'currentCompany', type: 'String'),
       'industry': const FieldInfo(
           name: 'industry', columnName: 'industry', type: 'String'),
       'skillsToDevelop': const FieldInfo(
-          name: 'skillsToDevelop',
-          columnName: 'skillsToDevelop',
-          type: 'Json'),
+          name: 'skillsToDevelop', columnName: 'skillsToDevelop', type: 'Json'),
       'linkedinUrl': const FieldInfo(
           name: 'linkedinUrl', columnName: 'linkedinUrl', type: 'String'),
       'budgetPreference': const FieldInfo(
@@ -325,8 +321,8 @@ SchemaRegistry buildSchemaRegistry() {
           name: 'preferredLanguage',
           columnName: 'preferredLanguage',
           type: 'String'),
-      'goals': const FieldInfo(
-          name: 'goals', columnName: 'goals', type: 'String'),
+      'goals':
+          const FieldInfo(name: 'goals', columnName: 'goals', type: 'String'),
       'createdAt': const FieldInfo(
           name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
       'updatedAt': const FieldInfo(
@@ -362,7 +358,9 @@ SchemaRegistry buildSchemaRegistry() {
       'priceCurrency': const FieldInfo(
           name: 'priceCurrency', columnName: 'priceCurrency', type: 'String'),
       'durationInMonths': const FieldInfo(
-          name: 'durationInMonths', columnName: 'durationInMonths', type: 'Int'),
+          name: 'durationInMonths',
+          columnName: 'durationInMonths',
+          type: 'Int'),
       'callsPerWeek': const FieldInfo(
           name: 'callsPerWeek', columnName: 'callsPerWeek', type: 'Int'),
       'sessionDurationInHours': const FieldInfo(
@@ -733,13 +731,9 @@ SchemaRegistry buildSchemaRegistry() {
           columnName: 'consultantProfileId',
           type: 'String'),
       'startsAt': const FieldInfo(
-          name: 'startsAt',
-          columnName: 'startsAt',
-          type: 'DateTime'),
+          name: 'startsAt', columnName: 'startsAt', type: 'DateTime'),
       'endsAt': const FieldInfo(
-          name: 'endsAt',
-          columnName: 'endsAt',
-          type: 'DateTime'),
+          name: 'endsAt', columnName: 'endsAt', type: 'DateTime'),
       'createdAt': const FieldInfo(
           name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
       'updatedAt': const FieldInfo(
@@ -758,21 +752,13 @@ SchemaRegistry buildSchemaRegistry() {
           columnName: 'consultantProfileId',
           type: 'String'),
       'startDay': const FieldInfo(
-          name: 'startDay',
-          columnName: 'startDay',
-          type: 'String'),
+          name: 'startDay', columnName: 'startDay', type: 'String'),
       'startTimeUtc': const FieldInfo(
-          name: 'startTimeUtc',
-          columnName: 'startTimeUtc',
-          type: 'Int'),
-      'endDay': const FieldInfo(
-          name: 'endDay',
-          columnName: 'endDay',
-          type: 'String'),
+          name: 'startTimeUtc', columnName: 'startTimeUtc', type: 'Int'),
+      'endDay':
+          const FieldInfo(name: 'endDay', columnName: 'endDay', type: 'String'),
       'endTimeUtc': const FieldInfo(
-          name: 'endTimeUtc',
-          columnName: 'endTimeUtc',
-          type: 'Int'),
+          name: 'endTimeUtc', columnName: 'endTimeUtc', type: 'Int'),
       'utcOffsetMinutes': const FieldInfo(
           name: 'utcOffsetMinutes',
           columnName: 'utcOffsetMinutes',
@@ -1299,25 +1285,19 @@ SchemaRegistry buildSchemaRegistry() {
       'paymentIntent': const FieldInfo(
           name: 'paymentIntent', columnName: 'paymentIntent', type: 'String'),
       'paymentGateway': const FieldInfo(
-          name: 'paymentGateway',
-          columnName: 'paymentGateway',
-          type: 'String'),
+          name: 'paymentGateway', columnName: 'paymentGateway', type: 'String'),
       'paymentStatus': const FieldInfo(
           name: 'paymentStatus', columnName: 'paymentStatus', type: 'String'),
       'expiresAt': const FieldInfo(
           name: 'expiresAt', columnName: 'expiresAt', type: 'DateTime'),
       'isMockPayment': const FieldInfo(
-          name: 'isMockPayment',
-          columnName: 'isMockPayment',
-          type: 'Boolean'),
+          name: 'isMockPayment', columnName: 'isMockPayment', type: 'Boolean'),
       'userId':
           const FieldInfo(name: 'userId', columnName: 'userId', type: 'String'),
       'appointmentId': const FieldInfo(
           name: 'appointmentId', columnName: 'appointmentId', type: 'String'),
       'discountCodeId': const FieldInfo(
-          name: 'discountCodeId',
-          columnName: 'discountCodeId',
-          type: 'String'),
+          name: 'discountCodeId', columnName: 'discountCodeId', type: 'String'),
       'createdAt': const FieldInfo(
           name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
       'updatedAt': const FieldInfo(
@@ -1385,16 +1365,14 @@ SchemaRegistry buildSchemaRegistry() {
           const FieldInfo(name: 'amount', columnName: 'amount', type: 'Int'),
       'currency': const FieldInfo(
           name: 'currency', columnName: 'currency', type: 'String'),
-      'reason': const FieldInfo(
-          name: 'reason', columnName: 'reason', type: 'String'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+      'reason':
+          const FieldInfo(name: 'reason', columnName: 'reason', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'refundId': const FieldInfo(
           name: 'refundId', columnName: 'refundId', type: 'String'),
       'paymentGateway': const FieldInfo(
-          name: 'paymentGateway',
-          columnName: 'paymentGateway',
-          type: 'String'),
+          name: 'paymentGateway', columnName: 'paymentGateway', type: 'String'),
       'metadata': const FieldInfo(
           name: 'metadata', columnName: 'metadata', type: 'Json'),
       'paymentId': const FieldInfo(
@@ -1424,20 +1402,18 @@ SchemaRegistry buildSchemaRegistry() {
           const FieldInfo(name: 'amount', columnName: 'amount', type: 'Int'),
       'currency': const FieldInfo(
           name: 'currency', columnName: 'currency', type: 'String'),
-      'reason': const FieldInfo(
-          name: 'reason', columnName: 'reason', type: 'String'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+      'reason':
+          const FieldInfo(name: 'reason', columnName: 'reason', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'disputeId': const FieldInfo(
           name: 'disputeId', columnName: 'disputeId', type: 'String'),
       'paymentGateway': const FieldInfo(
-          name: 'paymentGateway',
-          columnName: 'paymentGateway',
-          type: 'String'),
+          name: 'paymentGateway', columnName: 'paymentGateway', type: 'String'),
       'evidence': const FieldInfo(
           name: 'evidence', columnName: 'evidence', type: 'Json'),
-      'dueBy': const FieldInfo(
-          name: 'dueBy', columnName: 'dueBy', type: 'DateTime'),
+      'dueBy':
+          const FieldInfo(name: 'dueBy', columnName: 'dueBy', type: 'DateTime'),
       'isChargeRefundable': const FieldInfo(
           name: 'isChargeRefundable',
           columnName: 'isChargeRefundable',
@@ -1475,8 +1451,8 @@ SchemaRegistry buildSchemaRegistry() {
           const FieldInfo(name: 'rating', columnName: 'rating', type: 'Int'),
       'category': const FieldInfo(
           name: 'category', columnName: 'category', type: 'String'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'userId':
           const FieldInfo(name: 'userId', columnName: 'userId', type: 'String'),
       'createdAt': const FieldInfo(
@@ -1506,8 +1482,8 @@ SchemaRegistry buildSchemaRegistry() {
           name: 'eventId', columnName: 'eventId', type: 'String'),
       'eventType': const FieldInfo(
           name: 'eventType', columnName: 'eventType', type: 'String'),
-      'payload': const FieldInfo(
-          name: 'payload', columnName: 'payload', type: 'Json'),
+      'payload':
+          const FieldInfo(name: 'payload', columnName: 'payload', type: 'Json'),
       'signature': const FieldInfo(
           name: 'signature', columnName: 'signature', type: 'String'),
       'processed': const FieldInfo(
@@ -1572,15 +1548,11 @@ SchemaRegistry buildSchemaRegistry() {
     fields: {
       'id': FieldInfo.id(name: 'id'),
       'referralCodeId': const FieldInfo(
-          name: 'referralCodeId',
-          columnName: 'referralCodeId',
-          type: 'String'),
+          name: 'referralCodeId', columnName: 'referralCodeId', type: 'String'),
       'referredUserId': const FieldInfo(
-          name: 'referredUserId',
-          columnName: 'referredUserId',
-          type: 'String'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+          name: 'referredUserId', columnName: 'referredUserId', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'referrerRewardAmount': const FieldInfo(
           name: 'referrerRewardAmount',
           columnName: 'referrerRewardAmount',
@@ -1638,8 +1610,8 @@ SchemaRegistry buildSchemaRegistry() {
           const FieldInfo(name: 'amount', columnName: 'amount', type: 'Int'),
       'currency': const FieldInfo(
           name: 'currency', columnName: 'currency', type: 'String'),
-      'source': const FieldInfo(
-          name: 'source', columnName: 'source', type: 'String'),
+      'source':
+          const FieldInfo(name: 'source', columnName: 'source', type: 'String'),
       'referralId': const FieldInfo(
           name: 'referralId', columnName: 'referralId', type: 'String'),
       'usedAmount': const FieldInfo(
@@ -1684,8 +1656,8 @@ SchemaRegistry buildSchemaRegistry() {
           name: 'revenueSharePercentage',
           columnName: 'revenueSharePercentage',
           type: 'Float'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'invitedById': const FieldInfo(
           name: 'invitedById', columnName: 'invitedById', type: 'String'),
       'respondedAt': const FieldInfo(
@@ -1736,8 +1708,8 @@ SchemaRegistry buildSchemaRegistry() {
           name: 'revenueSharePercentage',
           columnName: 'revenueSharePercentage',
           type: 'Float'),
-      'status': const FieldInfo(
-          name: 'status', columnName: 'status', type: 'String'),
+      'status':
+          const FieldInfo(name: 'status', columnName: 'status', type: 'String'),
       'invitedById': const FieldInfo(
           name: 'invitedById', columnName: 'invitedById', type: 'String'),
       'respondedAt': const FieldInfo(
@@ -1800,8 +1772,8 @@ SchemaRegistry buildSchemaRegistry() {
       'role': const FieldInfo(name: 'role', columnName: 'role', type: 'String'),
       'dateOfBirth': const FieldInfo(
           name: 'dateOfBirth', columnName: 'dateOfBirth', type: 'DateTime'),
-      'gender': const FieldInfo(
-          name: 'gender', columnName: 'gender', type: 'String'),
+      'gender':
+          const FieldInfo(name: 'gender', columnName: 'gender', type: 'String'),
       'city': const FieldInfo(name: 'city', columnName: 'city', type: 'String'),
       'country': const FieldInfo(
           name: 'country', columnName: 'country', type: 'String'),
@@ -1923,6 +1895,122 @@ SchemaRegistry buildSchemaRegistry() {
           name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
       'updatedAt': const FieldInfo(
           name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+  ));
+
+  // CookiePreference (@@map → cookie_preferences)
+  schema.registerModel(ModelSchema(
+    name: 'CookiePreference',
+    tableName: 'cookie_preferences',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'userId':
+          const FieldInfo(name: 'userId', columnName: 'userId', type: 'String'),
+      'sessionId': const FieldInfo(
+          name: 'sessionId', columnName: 'sessionId', type: 'String'),
+      'essential': const FieldInfo(
+          name: 'essential', columnName: 'essential', type: 'Boolean'),
+      'analytics': const FieldInfo(
+          name: 'analytics', columnName: 'analytics', type: 'Boolean'),
+      'marketing': const FieldInfo(
+          name: 'marketing', columnName: 'marketing', type: 'Boolean'),
+      'functional': const FieldInfo(
+          name: 'functional', columnName: 'functional', type: 'Boolean'),
+      'consentGivenAt': const FieldInfo(
+          name: 'consentGivenAt',
+          columnName: 'consentGivenAt',
+          type: 'DateTime'),
+      'consentUpdatedAt': const FieldInfo(
+          name: 'consentUpdatedAt',
+          columnName: 'consentUpdatedAt',
+          type: 'DateTime'),
+    },
+    relations: {
+      'user': RelationInfo.oneToOne(
+        name: 'user',
+        targetModel: 'users',
+        foreignKey: 'userId',
+        isOwner: true,
+      ),
+    },
+  ));
+
+  // NotificationPreference (@@map → notification_preferences)
+  schema.registerModel(ModelSchema(
+    name: 'NotificationPreference',
+    tableName: 'notification_preferences',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'userId':
+          const FieldInfo(name: 'userId', columnName: 'userId', type: 'String'),
+      'allNotifications': const FieldInfo(
+          name: 'allNotifications',
+          columnName: 'allNotifications',
+          type: 'Boolean'),
+      'inAppEnabled': const FieldInfo(
+          name: 'inAppEnabled', columnName: 'inAppEnabled', type: 'Boolean'),
+      'emailEnabled': const FieldInfo(
+          name: 'emailEnabled', columnName: 'emailEnabled', type: 'Boolean'),
+      'pushEnabled': const FieldInfo(
+          name: 'pushEnabled', columnName: 'pushEnabled', type: 'Boolean'),
+      'mentions': const FieldInfo(
+          name: 'mentions', columnName: 'mentions', type: 'Boolean'),
+      'directMessages': const FieldInfo(
+          name: 'directMessages',
+          columnName: 'directMessages',
+          type: 'Boolean'),
+      'updates': const FieldInfo(
+          name: 'updates', columnName: 'updates', type: 'Boolean'),
+      'appointmentReminders': const FieldInfo(
+          name: 'appointmentReminders',
+          columnName: 'appointmentReminders',
+          type: 'Boolean'),
+      'paymentNotifications': const FieldInfo(
+          name: 'paymentNotifications',
+          columnName: 'paymentNotifications',
+          type: 'Boolean'),
+      'supportUpdates': const FieldInfo(
+          name: 'supportUpdates',
+          columnName: 'supportUpdates',
+          type: 'Boolean'),
+      'feedbackAlerts': const FieldInfo(
+          name: 'feedbackAlerts',
+          columnName: 'feedbackAlerts',
+          type: 'Boolean'),
+      'trialNotifications': const FieldInfo(
+          name: 'trialNotifications',
+          columnName: 'trialNotifications',
+          type: 'Boolean'),
+      'subscriptionAlerts': const FieldInfo(
+          name: 'subscriptionAlerts',
+          columnName: 'subscriptionAlerts',
+          type: 'Boolean'),
+      'marketingEmails': const FieldInfo(
+          name: 'marketingEmails',
+          columnName: 'marketingEmails',
+          type: 'Boolean'),
+      'quietHoursEnabled': const FieldInfo(
+          name: 'quietHoursEnabled',
+          columnName: 'quietHoursEnabled',
+          type: 'Boolean'),
+      'quietHoursStart': const FieldInfo(
+          name: 'quietHoursStart',
+          columnName: 'quietHoursStart',
+          type: 'String'),
+      'quietHoursEnd': const FieldInfo(
+          name: 'quietHoursEnd', columnName: 'quietHoursEnd', type: 'String'),
+      'quietHoursTimezone': const FieldInfo(
+          name: 'quietHoursTimezone',
+          columnName: 'quietHoursTimezone',
+          type: 'String'),
+    },
+    relations: {
+      'user': RelationInfo.oneToOne(
+        name: 'user',
+        targetModel: 'users',
+        foreignKey: 'userId',
+        isOwner: true,
+      ),
     },
   ));
 

--- a/backend/lib/services/auth/auth_service.dart
+++ b/backend/lib/services/auth/auth_service.dart
@@ -154,6 +154,9 @@ class AuthService {
         executor: txn,
       );
 
+      // Create default preferences (matches web BetterAuth databaseHooks)
+      await _db.users.createDefaultPreferences(userId, txn: txn);
+
       return newUser;
     });
 
@@ -291,6 +294,9 @@ class AuthService {
           executor: txn,
         );
 
+        // Create default preferences (matches web BetterAuth databaseHooks)
+        await _db.users.createDefaultPreferences(userId, txn: txn);
+
         return newUser;
       });
     } else {
@@ -383,6 +389,9 @@ class AuthService {
           userId: userId,
           executor: txn,
         );
+
+        // Create default preferences (matches web BetterAuth databaseHooks)
+        await _db.users.createDefaultPreferences(userId, txn: txn);
 
         return newUser;
       });

--- a/backend/test/services/auth/auth_service_test.dart
+++ b/backend/test/services/auth/auth_service_test.dart
@@ -58,6 +58,12 @@ void main() {
     when(() => mockDb.sessions).thenReturn(mockSessions);
     when(() => mockDb.consulteeProfiles).thenReturn(mockConsulteeProfiles);
 
+    // Default stub for createDefaultPreferences (called during signup)
+    when(() => mockUsers.createDefaultPreferences(
+          any(),
+          txn: any(named: 'txn'),
+        )).thenAnswer((_) async {});
+
     service = AuthService(mockDb, mockJwtService);
   });
 

--- a/lib/data/datasources/remote/auth_remote_source_mixin.dart
+++ b/lib/data/datasources/remote/auth_remote_source_mixin.dart
@@ -30,6 +30,10 @@ mixin AuthRemoteSourceMixin implements AuthRemoteSource {
   /// Must NOT touch the auth state controller — the mixin handles that.
   Future<void> clearAuthCredentials();
 
+  /// Sign out of the Google SDK (platform-specific).
+  /// Should NOT clear credentials or update auth state — the mixin handles that.
+  Future<void> signOutGoogleSdk();
+
   /// The broadcast controller that drives [authStateChanges].
   StreamController<UserModel?> get authStateController;
 
@@ -465,6 +469,39 @@ mixin AuthRemoteSourceMixin implements AuthRemoteSource {
           stackTrace: stackTrace, context: 'AuthRemoteSource.updateProfile');
       throw const AuthException(
         message: 'Failed to update profile. Please try again.',
+      );
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    try {
+      // Invalidate server-side session
+      final token = await getAuthToken();
+      if (token != null && token.isNotEmpty) {
+        try {
+          await http.post(
+            Uri.parse('$baseUrl/api/auth/sign-out'),
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $token',
+            },
+          );
+        } catch (_) {
+          // Server sign-out failure is non-critical — still clear local auth
+        }
+      }
+      await signOutGoogleSdk();
+      await clearAuthCredentials();
+      authStateController.add(null);
+    } catch (e, stackTrace) {
+      // Even if sign out fails, still clear local auth
+      await clearAuthCredentials();
+      authStateController.add(null);
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stackTrace,
+        context: 'AuthRemoteSource.signOut',
       );
     }
   }

--- a/lib/data/datasources/remote/auth_remote_source_mobile.dart
+++ b/lib/data/datasources/remote/auth_remote_source_mobile.dart
@@ -188,17 +188,11 @@ class AuthRemoteSourceImpl with AuthRemoteSourceMixin implements AuthRemoteSourc
   }
 
   @override
-  Future<void> signOut() async {
+  Future<void> signOutGoogleSdk() async {
     try {
       await googleSignIn.signOut();
-      await clearAuthCredentials();
-      authStateController.add(null);
-    } catch (e, stackTrace) {
-      // Even if sign out fails, still clear local auth
-      await clearAuthCredentials();
-      authStateController.add(null);
-      AppSentryLogger.captureException(e,
-          stackTrace: stackTrace, context: 'AuthRemoteSource.signOut');
+    } catch (_) {
+      // Google SDK sign-out failure is non-critical
     }
   }
 }

--- a/lib/data/datasources/remote/auth_remote_source_web.dart
+++ b/lib/data/datasources/remote/auth_remote_source_web.dart
@@ -125,26 +125,11 @@ class AuthRemoteSourceWebImpl
   }
 
   @override
-  Future<void> signOut() async {
+  Future<void> signOutGoogleSdk() async {
     try {
       await googleSignIn.signOut();
-      // On web, also notify the backend to invalidate the session
-      final token = await getAuthToken();
-      if (token != null) {
-        await http.post(
-          Uri.parse('${EnvConfig.apiBaseUrl}/api/auth/sign-out'),
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer $token',
-          },
-        );
-      }
-      await clearAuthCredentials();
-      authStateController.add(null);
     } catch (_) {
-      // Even if sign out fails on server, clear local auth
-      await clearAuthCredentials();
-      authStateController.add(null);
+      // Google SDK sign-out failure is non-critical
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Signup hook alignment**: Mobile signup now creates `CookiePreference` and `NotificationPreference` records (matching web's BetterAuth `databaseHooks.user.create`), fixing data inconsistency between platforms
- **Sign-out bug fix**: Mobile sign-out now invalidates the server-side session (was only clearing local storage, unlike web)
- **Auth remote source dedup**: Extracted shared sign-out logic into `AuthRemoteSourceMixin`, reducing platform impls from ~15 lines to ~5 lines each
- **Schema registry**: Registered `CookiePreference` and `NotificationPreference` models with all fields and relations

## Changes
| File | Change |
|------|--------|
| `backend/lib/database/schema_registry_builder.dart` | Register CookiePreference + NotificationPreference models |
| `backend/lib/database/repositories/user_repository.dart` | Add `createDefaultPreferences()` method |
| `backend/lib/services/auth/auth_service.dart` | Call preferences creation in all 3 signup paths |
| `backend/test/services/auth/auth_service_test.dart` | Add mock for new method |
| `lib/data/datasources/remote/auth_remote_source_mixin.dart` | Add shared signOut + signOutGoogleSdk bridge |
| `lib/data/datasources/remote/auth_remote_source_mobile.dart` | Replace signOut with signOutGoogleSdk |
| `lib/data/datasources/remote/auth_remote_source_web.dart` | Replace signOut with signOutGoogleSdk |

## Test plan
- [x] All 19 auth service tests pass (0 regressions)
- [x] Full backend test suite: 300 pass, 3 pre-existing failures in profile_service_test.dart
- [x] `dart analyze` clean on changed files (no new errors)
- [ ] Manual test: signup creates preference records in DB
- [ ] Manual test: sign-out invalidates server session on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)