### PR TITLE
fix: add profile image upload routes + document upload foundation

### DIFF
--- a/backend/routes/api/upload/document.dart
+++ b/backend/routes/api/upload/document.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+import 'dart:io' hide Platform;
+import 'dart:io' as io show Platform;
+
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+
+/// POST /api/upload/document
+///
+/// Returns a signed URL for uploading a document to Supabase Storage.
+/// Used for verification docs, appointment docs, support attachments, etc.
+///
+/// Request body:
+/// ```json
+/// {
+///   "fileName": "report.pdf",
+///   "contentType": "application/pdf",
+///   "bucket": "verification-docs" | "appointment-docs" | "support-attachments",
+///   "prefix": "optional/subfolder"
+/// }
+/// ```
+///
+/// Response: { signedUrl, publicUrl, path, bucket, contentType }
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final fileName = body['fileName'] as String?;
+    final contentType =
+        body['contentType'] as String? ?? 'application/octet-stream';
+    final bucket = body['bucket'] as String?;
+    final prefix = body['prefix'] as String?;
+
+    if (fileName == null || bucket == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'fileName and bucket are required'},
+        },
+      );
+    }
+
+    // Validate bucket is allowed
+    const allowedBuckets = {
+      'verification-docs',
+      'appointment-docs',
+      'support-attachments',
+      'plan-materials',
+    };
+    if (!allowedBuckets.contains(bucket)) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Invalid bucket. '
+                'Allowed: ${allowedBuckets.join(", ")}',
+          },
+        },
+      );
+    }
+
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final extension = fileName.split('.').lastOrNull ?? 'bin';
+    final basePath = prefix != null ? '$userId/$prefix' : userId;
+    final storagePath = '$basePath/$timestamp.$extension';
+
+    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
+    final supabaseServiceKey =
+        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
+
+    if (supabaseUrl == null || supabaseServiceKey == null) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Supabase configuration missing'},
+        },
+      );
+    }
+
+    final signedUrlResponse = await http.post(
+      Uri.parse(
+        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
+      ),
+      headers: {
+        'Authorization': 'Bearer $supabaseServiceKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'expiresIn': 3600}),
+    );
+
+    if (signedUrlResponse.statusCode != 200) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Failed to generate signed URL'},
+        },
+      );
+    }
+
+    final signedUrlData =
+        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
+    final token = signedUrlData['token'] as String?;
+    final publicUrl =
+        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
+    final fullSignedUrl = token != null
+        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
+            '$storagePath?token=$token'
+        : signedUrlData['url'] as String;
+
+    return Response.json(
+      body: {
+        'signedUrl': fullSignedUrl,
+        'publicUrl': publicUrl,
+        'path': storagePath,
+        'bucket': bucket,
+        'contentType': contentType,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document upload URL generation failed',
+      context: 'DocumentUpload',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to generate upload URL'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/user/profile-display-image/index.dart
+++ b/backend/routes/api/user/profile-display-image/index.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io' hide Platform;
+import 'dart:io' as io show Platform;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// POST /api/user/profile-display-image — Signed URL for explore grid image
+/// DELETE /api/user/profile-display-image — Remove display image
+///
+/// The profile display image is the square image shown on the Explore Experts
+/// grid. It's separate from the regular profile image (avatar).
+///
+/// After client uploads to signedUrl, call PUT /api/user/:id with
+/// { profileDisplayImage: publicUrl }.
+Future<Response> onRequest(RequestContext context) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.post) {
+    return _handlePost(context);
+  } else if (method == HttpMethod.delete) {
+    return _handleDelete(context);
+  }
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handlePost(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final fileName = body['fileName'] as String?;
+    final contentType = body['contentType'] as String? ?? 'image/jpeg';
+
+    if (fileName == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'fileName is required'},
+        },
+      );
+    }
+
+    const bucket = 'avatars';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final extension = fileName.split('.').lastOrNull ?? 'jpg';
+    final storagePath = '$userId/display-$timestamp.$extension';
+
+    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
+    final supabaseServiceKey =
+        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
+
+    if (supabaseUrl == null || supabaseServiceKey == null) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Supabase configuration missing'},
+        },
+      );
+    }
+
+    final signedUrlResponse = await http.post(
+      Uri.parse(
+        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
+      ),
+      headers: {
+        'Authorization': 'Bearer $supabaseServiceKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'expiresIn': 3600}),
+    );
+
+    if (signedUrlResponse.statusCode != 200) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Failed to generate signed URL'},
+        },
+      );
+    }
+
+    final signedUrlData =
+        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
+    final token = signedUrlData['token'] as String?;
+    final publicUrl =
+        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
+    final fullSignedUrl = token != null
+        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
+            '$storagePath?token=$token'
+        : signedUrlData['url'] as String;
+
+    return Response.json(
+      body: {
+        'signedUrl': fullSignedUrl,
+        'publicUrl': publicUrl,
+        'path': storagePath,
+        'bucket': bucket,
+        'contentType': contentType,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Profile display image upload URL generation failed',
+      context: 'ProfileDisplayImageUpload',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to generate upload URL'},
+      },
+    );
+  }
+}
+
+Future<Response> _handleDelete(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    // Clear profileDisplayImage via JsonQueryBuilder
+    final query = JsonQueryBuilder()
+        .model('users')
+        .action(QueryAction.update)
+        .where({'id': userId})
+        .data({
+          'profileDisplayImage': null,
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        })
+        .build();
+    await db.executor.executeMutation(query);
+
+    return Response.json(
+      body: {'message': 'Profile display image removed'},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Profile display image deletion failed',
+      context: 'ProfileDisplayImageDelete',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to remove display image'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/user/profile-image/index.dart
+++ b/backend/routes/api/user/profile-image/index.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+import 'dart:io' hide Platform;
+import 'dart:io' as io show Platform;
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// POST /api/user/profile-image — Get signed URL for profile image upload
+/// DELETE /api/user/profile-image — Remove profile image
+///
+/// POST response: { signedUrl, publicUrl, path, bucket }
+/// After client uploads to signedUrl, the publicUrl is the permanent URL.
+/// Client should then PUT /api/user/:id with { image: publicUrl }.
+Future<Response> onRequest(RequestContext context) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.post) {
+    return _handlePost(context);
+  } else if (method == HttpMethod.delete) {
+    return _handleDelete(context);
+  }
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handlePost(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final fileName = body['fileName'] as String?;
+    final contentType = body['contentType'] as String? ?? 'image/jpeg';
+
+    if (fileName == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'fileName is required'},
+        },
+      );
+    }
+
+    const bucket = 'avatars';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final extension = fileName.split('.').lastOrNull ?? 'jpg';
+    final storagePath = '$userId/profile-$timestamp.$extension';
+
+    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
+    final supabaseServiceKey =
+        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
+
+    if (supabaseUrl == null || supabaseServiceKey == null) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Supabase configuration missing'},
+        },
+      );
+    }
+
+    final signedUrlResponse = await http.post(
+      Uri.parse(
+        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
+      ),
+      headers: {
+        'Authorization': 'Bearer $supabaseServiceKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'expiresIn': 3600}),
+    );
+
+    if (signedUrlResponse.statusCode != 200) {
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'error': {'message': 'Failed to generate signed URL'},
+        },
+      );
+    }
+
+    final signedUrlData =
+        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
+    final token = signedUrlData['token'] as String?;
+    final publicUrl =
+        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
+    final fullSignedUrl = token != null
+        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
+            '$storagePath?token=$token'
+        : signedUrlData['url'] as String;
+
+    return Response.json(
+      body: {
+        'signedUrl': fullSignedUrl,
+        'publicUrl': publicUrl,
+        'path': storagePath,
+        'bucket': bucket,
+        'contentType': contentType,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Profile image upload URL generation failed',
+      context: 'ProfileImageUpload',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to generate upload URL'},
+      },
+    );
+  }
+}
+
+Future<Response> _handleDelete(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    // Clear the image field via JsonQueryBuilder
+    final query = JsonQueryBuilder()
+        .model('users')
+        .action(QueryAction.update)
+        .where({'id': userId})
+        .data({
+          'image': null,
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        })
+        .build();
+    await db.executor.executeMutation(query);
+
+    return Response.json(body: {'message': 'Profile image removed'});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Profile image deletion failed',
+      context: 'ProfileImageDelete',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to remove profile image'},
+      },
+    );
+  }
+}

--- a/lib/core/utils/file_upload_helper.dart
+++ b/lib/core/utils/file_upload_helper.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+/// Helper for uploading files to Supabase Storage via signed URLs.
+///
+/// The flow is:
+/// 1. Call the backend to get a signed upload URL
+/// 2. Upload the file directly to Supabase using the signed URL
+/// 3. Use the returned publicUrl in subsequent API calls
+///
+/// This helper handles step 2. Steps 1 and 3 are handled by the caller.
+class FileUploadHelper {
+  /// Upload a file to a signed URL.
+  ///
+  /// Returns true if the upload succeeded (HTTP 200).
+  /// Throws on network errors.
+  static Future<bool> uploadToSignedUrl({
+    required String signedUrl,
+    required File file,
+    required String contentType,
+  }) async {
+    final bytes = await file.readAsBytes();
+
+    final response = await http.put(
+      Uri.parse(signedUrl),
+      headers: {
+        'Content-Type': contentType,
+        'x-upsert': 'true',
+      },
+      body: bytes,
+    );
+
+    return response.statusCode == 200;
+  }
+
+  /// Upload bytes to a signed URL (for web/memory uploads).
+  static Future<bool> uploadBytesToSignedUrl({
+    required String signedUrl,
+    required List<int> bytes,
+    required String contentType,
+  }) async {
+    final response = await http.put(
+      Uri.parse(signedUrl),
+      headers: {
+        'Content-Type': contentType,
+        'x-upsert': 'true',
+      },
+      body: bytes,
+    );
+
+    return response.statusCode == 200;
+  }
+}


### PR DESCRIPTION
## Summary
- Add dedicated `POST/DELETE /api/user/profile-image` route for profile avatar uploads via Supabase signed URLs
- Add dedicated `POST/DELETE /api/user/profile-display-image` route for explore grid image (separate from avatar)
- Add generic `POST /api/upload/document` route with bucket validation (verification-docs, appointment-docs, support-attachments, plan-materials) — foundation for upcoming phases
- Add `FileUploadHelper` frontend utility for uploading files/bytes to Supabase signed URLs

## Changes
| File | Change |
|------|--------|
| `backend/routes/api/user/profile-image/index.dart` | New POST/DELETE route |
| `backend/routes/api/user/profile-display-image/index.dart` | New POST/DELETE route |
| `backend/routes/api/upload/document.dart` | New generic document upload route |
| `lib/core/utils/file_upload_helper.dart` | New frontend upload utility |

## Notes
- Uses `JsonQueryBuilder` (Prisma Flutter Connector) for all DB operations — no raw SQL
- Handles `Platform` enum conflict (Prisma-generated) via `dart:io` hide/show pattern
- Follows existing `upload/image.dart` Supabase signed URL pattern

## Test plan
- [x] `dart analyze` clean on all new files
- [ ] Manual test: POST profile-image returns signed URL
- [ ] Manual test: Upload file to signed URL succeeds
- [ ] Manual test: DELETE profile-image clears image field

🤖 Generated with [Claude Code](https://claude.com/claude-code)