### PR TITLE
feature: add consultant verification backend routes

### DIFF
--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -109,6 +109,8 @@ class DatabaseClient {
     _verificationRepository = VerificationRepository(_executor);
     _collaboratorRepository = CollaboratorRepository(_executor);
     _referralRepository = ReferralRepository(_executor);
+    _consultantVerificationRepository =
+        ConsultantVerificationRepository(_executor, _prisma);
   }
 
   static DatabaseClient? _instance;
@@ -142,6 +144,8 @@ class DatabaseClient {
   late final VerificationRepository _verificationRepository;
   late final CollaboratorRepository _collaboratorRepository;
   late final ReferralRepository _referralRepository;
+  late final ConsultantVerificationRepository
+      _consultantVerificationRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -270,6 +274,10 @@ class DatabaseClient {
 
   /// Referral repository (for referral codes and credits)
   ReferralRepository get referrals => _referralRepository;
+
+  /// Consultant verification repository (for profile verification workflow)
+  ConsultantVerificationRepository get consultantVerifications =>
+      _consultantVerificationRepository;
 
   /// Execute raw SQL query and return results as maps
   Future<List<Map<String, dynamic>>> executeRaw(

--- a/backend/lib/database/repositories/consultant_verification_repository.dart
+++ b/backend/lib/database/repositories/consultant_verification_repository.dart
@@ -1,0 +1,123 @@
+import 'package:backend/database/database_client.dart';
+import 'package:backend/database/repositories/base_repository.dart';
+
+/// Repository for consultant profile verification operations.
+///
+/// Uses PrismaClient typed delegates for type-safe CRUD.
+/// Maps to `ConsultantProfileVerification` and `ProfileVerificationDocument`.
+class ConsultantVerificationRepository extends BaseRepository {
+  ConsultantVerificationRepository(super._executor, this._prisma);
+
+  final PrismaClient _prisma;
+
+  /// Create a new verification request with optional document refs.
+  Future<ConsultantProfileVerification> submit({
+    required String consultantProfileId,
+    String? notes,
+  }) async {
+    return _prisma.consultantProfileVerification.create(
+      data: CreateConsultantProfileVerificationInput(
+        consultantProfileId: consultantProfileId,
+        notes: notes,
+      ),
+    );
+  }
+
+  /// Get the latest verification for a consultant profile.
+  Future<ConsultantProfileVerification?> findLatest(
+    String consultantProfileId,
+  ) async {
+    final results = await _prisma.consultantProfileVerification.findMany(
+      where: ConsultantProfileVerificationWhereInput(
+        consultantProfileId: StringFilter(equals: consultantProfileId),
+      ),
+      orderBy: const ConsultantProfileVerificationOrderByInput(
+        createdAt: SortOrder.desc,
+      ),
+      take: 1,
+    );
+    return results.isEmpty ? null : results.first;
+  }
+
+  /// Get a verification by ID.
+  Future<ConsultantProfileVerification?> findById(String id) async {
+    return _prisma.consultantProfileVerification.findUnique(
+      where: ConsultantProfileVerificationWhereUniqueInput(id: id),
+    );
+  }
+
+  /// Get all verifications for a consultant profile.
+  Future<List<ConsultantProfileVerification>> findAll(
+    String consultantProfileId,
+  ) async {
+    return _prisma.consultantProfileVerification.findMany(
+      where: ConsultantProfileVerificationWhereInput(
+        consultantProfileId: StringFilter(equals: consultantProfileId),
+      ),
+      orderBy: const ConsultantProfileVerificationOrderByInput(
+        createdAt: SortOrder.desc,
+      ),
+    );
+  }
+
+  /// Add a document to an existing verification.
+  Future<ProfileVerificationDocument> addDocument({
+    required String verificationId,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+  }) async {
+    return _prisma.profileVerificationDocument.create(
+      data: CreateProfileVerificationDocumentInput(
+        verificationId: verificationId,
+        fileName: fileName,
+        originalName: originalName,
+        fileSize: fileSize,
+        mimeType: mimeType,
+        fileUrl: fileUrl,
+        storagePath: storagePath,
+        description: description,
+      ),
+    );
+  }
+
+  /// Get all documents for a verification.
+  Future<List<ProfileVerificationDocument>> getDocuments(
+    String verificationId,
+  ) async {
+    return _prisma.profileVerificationDocument.findMany(
+      where: ProfileVerificationDocumentWhereInput(
+        verificationId: StringFilter(equals: verificationId),
+      ),
+    );
+  }
+
+  /// Resubmit a verification (creates a new one, supersedes the old).
+  Future<ConsultantProfileVerification> resubmit({
+    required String consultantProfileId,
+    required String previousVerificationId,
+    String? notes,
+  }) async {
+    // Mark previous as superseded
+    await _prisma.consultantProfileVerification.update(
+      where: ConsultantProfileVerificationWhereUniqueInput(
+        id: previousVerificationId,
+      ),
+      data: const UpdateConsultantProfileVerificationInput(
+        status: ProfileVerificationStatus.superseded,
+      ),
+    );
+
+    // Create new verification
+    return _prisma.consultantProfileVerification.create(
+      data: CreateConsultantProfileVerificationInput(
+        consultantProfileId: consultantProfileId,
+        notes: notes,
+      ),
+    );
+  }
+}

--- a/backend/lib/database/repositories/consultant_verification_repository.dart
+++ b/backend/lib/database/repositories/consultant_verification_repository.dart
@@ -1,11 +1,21 @@
 import 'package:backend/database/database_client.dart';
 import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Thrown when a verification submission conflicts with an existing pending one.
+class VerificationConflictException implements Exception {
+  const VerificationConflictException();
+
+  @override
+  String toString() => 'A verification request is already pending';
+}
 
 /// Repository for consultant profile verification operations.
 ///
 /// Uses PrismaClient typed delegates for type-safe CRUD.
 /// Maps to `ConsultantProfileVerification` and `ProfileVerificationDocument`.
 class ConsultantVerificationRepository extends BaseRepository {
+  /// Creates a repository with query executor and PrismaClient.
   ConsultantVerificationRepository(super._executor, this._prisma);
 
   final PrismaClient _prisma;
@@ -21,6 +31,52 @@ class ConsultantVerificationRepository extends BaseRepository {
         notes: notes,
       ),
     );
+  }
+
+  /// Atomically check for pending verification and submit a new one.
+  ///
+  /// Wraps the findLatest + submit in a transaction to prevent
+  /// race conditions where concurrent requests both pass the check.
+  /// Throws [VerificationConflictException] if a pending one exists.
+  Future<ConsultantProfileVerification> submitIfNoPending({
+    required String consultantProfileId,
+    String? notes,
+  }) async {
+    return executeInTransaction((txn) async {
+      // Check for existing pending verification within transaction
+      final checkQuery = JsonQueryBuilder()
+          .model('ConsultantProfileVerification')
+          .action(QueryAction.findFirst)
+          .where({
+        'consultantProfileId': consultantProfileId,
+        'status': 'PENDING',
+      }).build();
+
+      final existing = await txn.executeQueryAsSingleMap(checkQuery);
+      if (existing != null) {
+        throw const VerificationConflictException();
+      }
+
+      // Create new verification within same transaction
+      final now = nowIso8601;
+      final createQuery = JsonQueryBuilder()
+          .model('ConsultantProfileVerification')
+          .action(QueryAction.create)
+          .data({
+        'consultantProfileId': consultantProfileId,
+        'status': 'PENDING',
+        'notes': notes,
+        'submittedAt': now,
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+
+      final result = await txn.executeQueryAsSingleMap(createQuery);
+      if (result == null) {
+        throw Exception('Failed to create verification');
+      }
+      return ConsultantProfileVerification.fromJson(result);
+    });
   }
 
   /// Get the latest verification for a consultant profile.

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -8,6 +8,7 @@ export 'appointment_repository.dart';
 export 'base_repository.dart';
 export 'checkout_repository.dart';
 export 'collaborator_repository.dart';
+export 'consultant_verification_repository.dart';
 export 'consultant_explore_repository.dart';
 export 'dashboard_repository.dart';
 export 'consultant_profile_repository.dart';

--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -2014,5 +2014,102 @@ SchemaRegistry buildSchemaRegistry() {
     },
   ));
 
+  // ConsultantProfileVerification (no @@map, uses model name as table)
+  schema.registerModel(ModelSchema(
+    name: 'ConsultantProfileVerification',
+    tableName: 'ConsultantProfileVerification',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'status': const FieldInfo(
+          name: 'status', columnName: 'status', type: 'String'),
+      'consultantProfileId': const FieldInfo(
+          name: 'consultantProfileId',
+          columnName: 'consultantProfileId',
+          type: 'String'),
+      'submittedAt': const FieldInfo(
+          name: 'submittedAt', columnName: 'submittedAt', type: 'DateTime'),
+      'notes': const FieldInfo(
+          name: 'notes', columnName: 'notes', type: 'String'),
+      'reviewedAt': const FieldInfo(
+          name: 'reviewedAt', columnName: 'reviewedAt', type: 'DateTime'),
+      'reviewedById': const FieldInfo(
+          name: 'reviewedById',
+          columnName: 'reviewedById',
+          type: 'String'),
+      'reviewNotes': const FieldInfo(
+          name: 'reviewNotes', columnName: 'reviewNotes', type: 'String'),
+      'rejectionReason': const FieldInfo(
+          name: 'rejectionReason',
+          columnName: 'rejectionReason',
+          type: 'String'),
+      'feedbackDetails': const FieldInfo(
+          name: 'feedbackDetails',
+          columnName: 'feedbackDetails',
+          type: 'String'),
+      'createdAt': const FieldInfo(
+          name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'consultantProfile': RelationInfo.oneToOne(
+        name: 'consultantProfile',
+        targetModel: 'ConsultantProfile',
+        foreignKey: 'consultantProfileId',
+        isOwner: true,
+      ),
+      'documents': RelationInfo.oneToMany(
+        name: 'documents',
+        targetModel: 'ProfileVerificationDocument',
+        foreignKey: 'verificationId',
+      ),
+    },
+  ));
+
+  // ProfileVerificationDocument (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'ProfileVerificationDocument',
+    tableName: 'ProfileVerificationDocument',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'fileName': const FieldInfo(
+          name: 'fileName', columnName: 'fileName', type: 'String'),
+      'originalName': const FieldInfo(
+          name: 'originalName',
+          columnName: 'originalName',
+          type: 'String'),
+      'fileSize': const FieldInfo(
+          name: 'fileSize', columnName: 'fileSize', type: 'Int'),
+      'mimeType': const FieldInfo(
+          name: 'mimeType', columnName: 'mimeType', type: 'String'),
+      'fileUrl': const FieldInfo(
+          name: 'fileUrl', columnName: 'fileUrl', type: 'String'),
+      'storagePath': const FieldInfo(
+          name: 'storagePath', columnName: 'storagePath', type: 'String'),
+      'description': const FieldInfo(
+          name: 'description', columnName: 'description', type: 'String'),
+      'isValid': const FieldInfo(
+          name: 'isValid', columnName: 'isValid', type: 'Boolean'),
+      'staffFeedback': const FieldInfo(
+          name: 'staffFeedback',
+          columnName: 'staffFeedback',
+          type: 'String'),
+      'verificationId': const FieldInfo(
+          name: 'verificationId',
+          columnName: 'verificationId',
+          type: 'String'),
+      'uploadedAt': const FieldInfo(
+          name: 'uploadedAt', columnName: 'uploadedAt', type: 'DateTime'),
+    },
+    relations: {
+      'verification': RelationInfo.oneToOne(
+        name: 'verification',
+        targetModel: 'ConsultantProfileVerification',
+        foreignKey: 'verificationId',
+        isOwner: true,
+      ),
+    },
+  ));
+
   return schema;
 }

--- a/backend/routes/api/verification/documents.dart
+++ b/backend/routes/api/verification/documents.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/verification/documents — List verification documents
+/// POST /api/verification/documents — Add a document to current verification
+///
+/// POST body:
+/// ```json
+/// {
+///   "fileName": "id-card.pdf",
+///   "originalName": "My ID Card.pdf",
+///   "fileSize": 102400,
+///   "mimeType": "application/pdf",
+///   "fileUrl": "https://...",
+///   "storagePath": "userId/123.pdf",
+///   "description": "Government ID"
+/// }
+/// ```
+Future<Response> onRequest(RequestContext context) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) {
+    return _handleGet(context);
+  } else if (method == HttpMethod.post) {
+    return _handlePost(context);
+  }
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId = user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can view documents'},
+        },
+      );
+    }
+
+    final verification = await db.consultantVerifications.findLatest(
+      consultantProfileId,
+    );
+    if (verification == null) {
+      return Response.json(body: {'data': <dynamic>[]});
+    }
+
+    final documents = await db.consultantVerifications.getDocuments(
+      verification.id,
+    );
+
+    return Response.json(
+      body: {'data': documents.map((d) => d.toJson()).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Verification documents list failed',
+      context: 'VerificationDocuments',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to list documents'},
+      },
+    );
+  }
+}
+
+Future<Response> _handlePost(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId = user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can upload documents'},
+        },
+      );
+    }
+
+    final verification = await db.consultantVerifications.findLatest(
+      consultantProfileId,
+    );
+    if (verification == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Submit a verification request first',
+          },
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final fileName = body['fileName'] as String?;
+    final originalName = body['originalName'] as String?;
+    final fileSize = body['fileSize'] as int?;
+    final mimeType = body['mimeType'] as String?;
+    final fileUrl = body['fileUrl'] as String?;
+    final storagePath = body['storagePath'] as String?;
+    final description = body['description'] as String?;
+
+    if (fileName == null ||
+        originalName == null ||
+        fileSize == null ||
+        mimeType == null ||
+        fileUrl == null ||
+        storagePath == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'fileName, originalName, fileSize, mimeType, '
+                'fileUrl, and storagePath are required',
+          },
+        },
+      );
+    }
+
+    final document = await db.consultantVerifications.addDocument(
+      verificationId: verification.id,
+      fileName: fileName,
+      originalName: originalName,
+      fileSize: fileSize,
+      mimeType: mimeType,
+      fileUrl: fileUrl,
+      storagePath: storagePath,
+      description: description,
+    );
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': document.toJson()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Verification document upload failed',
+      context: 'VerificationDocumentUpload',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to add document'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/verification/resubmit.dart
+++ b/backend/routes/api/verification/resubmit.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// POST /api/verification/resubmit
+///
+/// Resubmit a verification after rejection. Creates a new verification
+/// request and marks the previous one as SUPERSEDED.
+///
+/// Request body:
+/// ```json
+/// {
+///   "notes": "optional notes about changes made"
+/// }
+/// ```
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId = user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Only consultants can resubmit verification',
+          },
+        },
+      );
+    }
+
+    // Must have a previous rejected/needs_info verification
+    final existing = await db.consultantVerifications.findLatest(
+      consultantProfileId,
+    );
+    if (existing == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'No previous verification to resubmit',
+          },
+        },
+      );
+    }
+
+    if (existing.status != ProfileVerificationStatus.rejected &&
+        existing.status != ProfileVerificationStatus.needsInfo) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Can only resubmit rejected or needs-info '
+                'verifications. Current status: ${existing.status.name}',
+          },
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final notes = body['notes'] as String?;
+
+    final verification = await db.consultantVerifications.resubmit(
+      consultantProfileId: consultantProfileId,
+      previousVerificationId: existing.id,
+      notes: notes,
+    );
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': verification.toJson()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Verification resubmit failed',
+      context: 'VerificationResubmit',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to resubmit verification'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/verification/status.dart
+++ b/backend/routes/api/verification/status.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/verification/status
+///
+/// Get the current verification status for the authenticated consultant.
+///
+/// Response:
+/// ```json
+/// {
+///   "data": {
+///     "id": "...",
+///     "status": "PENDING" | "APPROVED" | "REJECTED" | "NEEDS_INFO",
+///     "submittedAt": "...",
+///     "rejectionReason": "...",
+///     "feedbackDetails": "...",
+///     "documents": [...]
+///   }
+/// }
+/// ```
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    if (user == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {
+          'error': {'message': 'User not found'},
+        },
+      );
+    }
+
+    final consultantProfileId = user['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Only consultants can check verification status',
+          },
+        },
+      );
+    }
+
+    final verification = await db.consultantVerifications.findLatest(
+      consultantProfileId,
+    );
+
+    if (verification == null) {
+      return Response.json(
+        body: {'data': null, 'message': 'No verification submitted'},
+      );
+    }
+
+    // Fetch documents for this verification
+    final documents = await db.consultantVerifications.getDocuments(
+      verification.id,
+    );
+
+    final verificationJson = verification.toJson();
+    verificationJson['documents'] =
+        documents.map((d) => d.toJson()).toList();
+
+    return Response.json(body: {'data': verificationJson});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Verification status check failed',
+      context: 'VerificationStatus',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to get verification status'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/verification/submit.dart
+++ b/backend/routes/api/verification/submit.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// POST /api/verification/submit
+///
+/// Submit a new consultant profile verification request.
+///
+/// Request body:
+/// ```json
+/// {
+///   "notes": "optional notes from the consultant"
+/// }
+/// ```
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    // Get consultant profile ID for this user
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    if (user == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {
+          'error': {'message': 'User not found'},
+        },
+      );
+    }
+
+    final consultantProfileId = user['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Only consultants can submit verification',
+          },
+        },
+      );
+    }
+
+    // Check if there's already a pending verification
+    final existing = await db.consultantVerifications.findLatest(
+      consultantProfileId,
+    );
+    if (existing != null &&
+        existing.status == ProfileVerificationStatus.pending) {
+      return Response.json(
+        statusCode: HttpStatus.conflict,
+        body: {
+          'error': {
+            'message': 'A verification request is already pending',
+          },
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final notes = body['notes'] as String?;
+
+    final verification = await db.consultantVerifications.submit(
+      consultantProfileId: consultantProfileId,
+      notes: notes,
+    );
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': verification.toJson()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Verification submit failed',
+      context: 'VerificationSubmit',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to submit verification'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/verification/submit.dart
+++ b/backend/routes/api/verification/submit.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:backend/database/database_client.dart';
+import 'package:backend/database/repositories/consultant_verification_repository.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
@@ -55,26 +56,11 @@ Future<Response> onRequest(RequestContext context) async {
       );
     }
 
-    // Check if there's already a pending verification
-    final existing = await db.consultantVerifications.findLatest(
-      consultantProfileId,
-    );
-    if (existing != null &&
-        existing.status == ProfileVerificationStatus.pending) {
-      return Response.json(
-        statusCode: HttpStatus.conflict,
-        body: {
-          'error': {
-            'message': 'A verification request is already pending',
-          },
-        },
-      );
-    }
-
     final body = await context.request.json() as Map<String, dynamic>;
     final notes = body['notes'] as String?;
 
-    final verification = await db.consultantVerifications.submit(
+    // Atomic check-and-submit to prevent race conditions
+    final verification = await db.consultantVerifications.submitIfNoPending(
       consultantProfileId: consultantProfileId,
       notes: notes,
     );
@@ -82,6 +68,15 @@ Future<Response> onRequest(RequestContext context) async {
     return Response.json(
       statusCode: HttpStatus.created,
       body: {'data': verification.toJson()},
+    );
+  } on VerificationConflictException {
+    return Response.json(
+      statusCode: HttpStatus.conflict,
+      body: {
+        'error': {
+          'message': 'A verification request is already pending',
+        },
+      },
     );
   } catch (e, stackTrace) {
     await SentryLogger.severe(


### PR DESCRIPTION
## Summary
- Add **ConsultantVerificationRepository** using PrismaClient typed delegates (no raw SQL)
- Register `ConsultantProfileVerification` and `ProfileVerificationDocument` models in schema registry
- Wire repository into `DatabaseClient` as `db.consultantVerifications`
- Regenerated Prisma client to include missing `SUPERSEDED` enum value

## New Routes
| Route | Method | Description |
|-------|--------|-------------|
| `/api/verification/submit` | POST | Submit new verification request |
| `/api/verification/status` | GET | Get latest verification status + documents |
| `/api/verification/documents` | GET/POST | List/upload verification documents |
| `/api/verification/resubmit` | POST | Resubmit after rejection (supersedes previous) |

## Business Rules
- Only consultants (users with `consultantProfileId`) can submit
- Cannot submit if a PENDING verification already exists
- Can only resubmit if status is REJECTED or NEEDS_INFO
- Resubmit marks previous as SUPERSEDED and creates new one

## Test plan
- [x] All 300 backend tests pass (0 regressions, same 3 pre-existing failures)
- [x] `dart analyze` clean on all new files
- [ ] Manual test: submit verification as consultant
- [ ] Manual test: upload document to verification
- [ ] Manual test: check status returns verification + documents
- [ ] Manual test: resubmit after rejection creates new verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)