### PR TITLE
feature: add consultant verification frontend

### DIFF
--- a/backend/lib/utils/storage_utils.dart
+++ b/backend/lib/utils/storage_utils.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:io' as io show Platform;
+
+import 'package:http/http.dart' as http;
+
+/// Shared utility for generating Supabase Storage signed upload URLs.
+///
+/// Used by profile image, profile display image, and document upload routes.
+class StorageUtils {
+  /// Generate a signed upload URL for Supabase Storage.
+  ///
+  /// Returns a map with:
+  /// - `signedUrl`: The URL to upload the file to
+  /// - `publicUrl`: The permanent public URL after upload
+  /// - `path`: The storage path
+  /// - `bucket`: The bucket name
+  static Future<Map<String, String>> generateSignedUploadUrl({
+    required String bucket,
+    required String storagePath,
+  }) async {
+    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
+    final supabaseServiceKey =
+        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
+
+    if (supabaseUrl == null || supabaseServiceKey == null) {
+      throw const StorageConfigException(
+        'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set',
+      );
+    }
+
+    final signedUrlResponse = await http.post(
+      Uri.parse(
+        '$supabaseUrl/storage/v1/object/upload/sign/'
+        '$bucket/$storagePath',
+      ),
+      headers: {
+        'Authorization': 'Bearer $supabaseServiceKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'expiresIn': 3600}),
+    );
+
+    if (signedUrlResponse.statusCode != 200) {
+      throw StorageException(
+        'Supabase signed URL error: ${signedUrlResponse.body}',
+      );
+    }
+
+    final signedUrlData =
+        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
+    final token = signedUrlData['token'] as String?;
+
+    final publicUrl =
+        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
+    final fullSignedUrl = token != null
+        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
+            '$storagePath?token=$token'
+        : signedUrlData['url'] as String;
+
+    return {
+      'signedUrl': fullSignedUrl,
+      'publicUrl': publicUrl,
+      'path': storagePath,
+      'bucket': bucket,
+    };
+  }
+
+  /// Extract file extension robustly from a filename.
+  ///
+  /// Returns [fallback] if no extension is found.
+  static String extractExtension(String fileName, {String fallback = 'bin'}) {
+    final dotIndex = fileName.lastIndexOf('.');
+    if (dotIndex != -1 && dotIndex < fileName.length - 1) {
+      return fileName.substring(dotIndex + 1);
+    }
+    return fallback;
+  }
+}
+
+/// Thrown when Supabase configuration is missing.
+class StorageConfigException implements Exception {
+  const StorageConfigException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Thrown when a Supabase Storage operation fails.
+class StorageException implements Exception {
+  const StorageException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/backend/routes/api/upload/document.dart
+++ b/backend/routes/api/upload/document.dart
@@ -1,11 +1,9 @@
-import 'dart:convert';
 import 'dart:io' hide Platform;
-import 'dart:io' as io show Platform;
 
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
+import 'package:backend/utils/storage_utils.dart';
 import 'package:dart_frog/dart_frog.dart';
-import 'package:http/http.dart' as http;
 
 /// POST /api/upload/document
 ///
@@ -17,7 +15,7 @@ import 'package:http/http.dart' as http;
 /// {
 ///   "fileName": "report.pdf",
 ///   "contentType": "application/pdf",
-///   "bucket": "verification-docs" | "appointment-docs" | "support-attachments",
+///   "bucket": "verification-docs",
 ///   "prefix": "optional/subfolder"
 /// }
 /// ```
@@ -55,7 +53,6 @@ Future<Response> onRequest(RequestContext context) async {
       );
     }
 
-    // Validate bucket is allowed
     const allowedBuckets = {
       'verification-docs',
       'appointment-docs',
@@ -75,60 +72,26 @@ Future<Response> onRequest(RequestContext context) async {
     }
 
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final extension = fileName.split('.').lastOrNull ?? 'bin';
+    final ext = StorageUtils.extractExtension(fileName);
     final basePath = prefix != null ? '$userId/$prefix' : userId;
-    final storagePath = '$basePath/$timestamp.$extension';
+    final storagePath = '$basePath/$timestamp.$ext';
 
-    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
-    final supabaseServiceKey =
-        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
-
-    if (supabaseUrl == null || supabaseServiceKey == null) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Supabase configuration missing'},
-        },
-      );
-    }
-
-    final signedUrlResponse = await http.post(
-      Uri.parse(
-        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
-      ),
-      headers: {
-        'Authorization': 'Bearer $supabaseServiceKey',
-        'Content-Type': 'application/json',
-      },
-      body: jsonEncode({'expiresIn': 3600}),
+    final urls = await StorageUtils.generateSignedUploadUrl(
+      bucket: bucket,
+      storagePath: storagePath,
     );
-
-    if (signedUrlResponse.statusCode != 200) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Failed to generate signed URL'},
-        },
-      );
-    }
-
-    final signedUrlData =
-        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
-    final token = signedUrlData['token'] as String?;
-    final publicUrl =
-        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
-    final fullSignedUrl = token != null
-        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
-            '$storagePath?token=$token'
-        : signedUrlData['url'] as String;
 
     return Response.json(
       body: {
-        'signedUrl': fullSignedUrl,
-        'publicUrl': publicUrl,
-        'path': storagePath,
-        'bucket': bucket,
+        ...urls,
         'contentType': contentType,
+      },
+    );
+  } on StorageConfigException {
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Supabase configuration missing'},
       },
     );
   } catch (e, stackTrace) {

--- a/backend/routes/api/user/profile-display-image/index.dart
+++ b/backend/routes/api/user/profile-display-image/index.dart
@@ -1,22 +1,14 @@
-import 'dart:convert';
 import 'dart:io' hide Platform;
-import 'dart:io' as io show Platform;
 
 import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
+import 'package:backend/utils/storage_utils.dart';
 import 'package:dart_frog/dart_frog.dart';
-import 'package:http/http.dart' as http;
 import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// POST /api/user/profile-display-image — Signed URL for explore grid image
 /// DELETE /api/user/profile-display-image — Remove display image
-///
-/// The profile display image is the square image shown on the Explore Experts
-/// grid. It's separate from the regular profile image (avatar).
-///
-/// After client uploads to signedUrl, call PUT /api/user/:id with
-/// { profileDisplayImage: publicUrl }.
 Future<Response> onRequest(RequestContext context) async {
   final method = context.request.method;
 
@@ -56,64 +48,27 @@ Future<Response> _handlePost(RequestContext context) async {
 
     const bucket = 'avatars';
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final extension = fileName.split('.').lastOrNull ?? 'jpg';
-    final storagePath = '$userId/display-$timestamp.$extension';
+    final ext = StorageUtils.extractExtension(fileName, fallback: 'jpg');
+    final storagePath = '$userId/display-$timestamp.$ext';
 
-    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
-    final supabaseServiceKey =
-        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
-
-    if (supabaseUrl == null || supabaseServiceKey == null) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Supabase configuration missing'},
-        },
-      );
-    }
-
-    final signedUrlResponse = await http.post(
-      Uri.parse(
-        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
-      ),
-      headers: {
-        'Authorization': 'Bearer $supabaseServiceKey',
-        'Content-Type': 'application/json',
-      },
-      body: jsonEncode({'expiresIn': 3600}),
+    final urls = await StorageUtils.generateSignedUploadUrl(
+      bucket: bucket,
+      storagePath: storagePath,
     );
 
-    if (signedUrlResponse.statusCode != 200) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Failed to generate signed URL'},
-        },
-      );
-    }
-
-    final signedUrlData =
-        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
-    final token = signedUrlData['token'] as String?;
-    final publicUrl =
-        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
-    final fullSignedUrl = token != null
-        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
-            '$storagePath?token=$token'
-        : signedUrlData['url'] as String;
-
     return Response.json(
+      body: {...urls, 'contentType': contentType},
+    );
+  } on StorageConfigException {
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
       body: {
-        'signedUrl': fullSignedUrl,
-        'publicUrl': publicUrl,
-        'path': storagePath,
-        'bucket': bucket,
-        'contentType': contentType,
+        'error': {'message': 'Supabase configuration missing'},
       },
     );
   } catch (e, stackTrace) {
     await SentryLogger.severe(
-      'Profile display image upload URL generation failed',
+      'Display image upload URL generation failed',
       context: 'ProfileDisplayImageUpload',
       error: e,
       stackTrace: stackTrace,
@@ -140,8 +95,6 @@ Future<Response> _handleDelete(RequestContext context) async {
     }
 
     final db = context.read<DatabaseClient>();
-
-    // Clear profileDisplayImage via JsonQueryBuilder
     final query = JsonQueryBuilder()
         .model('users')
         .action(QueryAction.update)
@@ -158,7 +111,7 @@ Future<Response> _handleDelete(RequestContext context) async {
     );
   } catch (e, stackTrace) {
     await SentryLogger.severe(
-      'Profile display image deletion failed',
+      'Display image deletion failed',
       context: 'ProfileDisplayImageDelete',
       error: e,
       stackTrace: stackTrace,

--- a/backend/routes/api/user/profile-image/index.dart
+++ b/backend/routes/api/user/profile-image/index.dart
@@ -1,20 +1,14 @@
-import 'dart:convert';
 import 'dart:io' hide Platform;
-import 'dart:io' as io show Platform;
 
 import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
+import 'package:backend/utils/storage_utils.dart';
 import 'package:dart_frog/dart_frog.dart';
-import 'package:http/http.dart' as http;
 import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// POST /api/user/profile-image — Get signed URL for profile image upload
 /// DELETE /api/user/profile-image — Remove profile image
-///
-/// POST response: { signedUrl, publicUrl, path, bucket }
-/// After client uploads to signedUrl, the publicUrl is the permanent URL.
-/// Client should then PUT /api/user/:id with { image: publicUrl }.
 Future<Response> onRequest(RequestContext context) async {
   final method = context.request.method;
 
@@ -54,59 +48,22 @@ Future<Response> _handlePost(RequestContext context) async {
 
     const bucket = 'avatars';
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final extension = fileName.split('.').lastOrNull ?? 'jpg';
-    final storagePath = '$userId/profile-$timestamp.$extension';
+    final ext = StorageUtils.extractExtension(fileName, fallback: 'jpg');
+    final storagePath = '$userId/profile-$timestamp.$ext';
 
-    final supabaseUrl = io.Platform.environment['SUPABASE_URL'];
-    final supabaseServiceKey =
-        io.Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
-
-    if (supabaseUrl == null || supabaseServiceKey == null) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Supabase configuration missing'},
-        },
-      );
-    }
-
-    final signedUrlResponse = await http.post(
-      Uri.parse(
-        '$supabaseUrl/storage/v1/object/upload/sign/$bucket/$storagePath',
-      ),
-      headers: {
-        'Authorization': 'Bearer $supabaseServiceKey',
-        'Content-Type': 'application/json',
-      },
-      body: jsonEncode({'expiresIn': 3600}),
+    final urls = await StorageUtils.generateSignedUploadUrl(
+      bucket: bucket,
+      storagePath: storagePath,
     );
 
-    if (signedUrlResponse.statusCode != 200) {
-      return Response.json(
-        statusCode: HttpStatus.internalServerError,
-        body: {
-          'error': {'message': 'Failed to generate signed URL'},
-        },
-      );
-    }
-
-    final signedUrlData =
-        jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
-    final token = signedUrlData['token'] as String?;
-    final publicUrl =
-        '$supabaseUrl/storage/v1/object/public/$bucket/$storagePath';
-    final fullSignedUrl = token != null
-        ? '$supabaseUrl/storage/v1/object/upload/sign/$bucket/'
-            '$storagePath?token=$token'
-        : signedUrlData['url'] as String;
-
     return Response.json(
+      body: {...urls, 'contentType': contentType},
+    );
+  } on StorageConfigException {
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
       body: {
-        'signedUrl': fullSignedUrl,
-        'publicUrl': publicUrl,
-        'path': storagePath,
-        'bucket': bucket,
-        'contentType': contentType,
+        'error': {'message': 'Supabase configuration missing'},
       },
     );
   } catch (e, stackTrace) {
@@ -138,8 +95,6 @@ Future<Response> _handleDelete(RequestContext context) async {
     }
 
     final db = context.read<DatabaseClient>();
-
-    // Clear the image field via JsonQueryBuilder
     final query = JsonQueryBuilder()
         .model('users')
         .action(QueryAction.update)

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -35,6 +35,8 @@ import '../features/support/screens/support_ticket_detail_screen.dart';
 import '../features/support/screens/create_ticket_screen.dart';
 import '../features/feedback/screens/feedback_screen.dart';
 import '../features/meetings/screens/meeting_screen.dart';
+import '../features/verification/screens/verification_status_screen.dart';
+import '../features/verification/screens/verification_submit_screen.dart';
 import 'providers/navigation_provider.dart';
 import 'shells/main_shell.dart';
 
@@ -438,6 +440,21 @@ GoRouter router(Ref ref) {
                 paramsData is DirectCheckoutParams ? paramsData : null,
           );
         },
+      ),
+
+      // Verification routes
+      GoRoute(
+        path: '/verification',
+        name: 'verification',
+        builder: (context, state) => const VerificationStatusScreen(),
+        routes: [
+          GoRoute(
+            path: 'submit',
+            name: 'verificationSubmit',
+            builder: (context, state) =>
+                const VerificationSubmitScreen(),
+          ),
+        ],
       ),
 
       // Support routes (PR#15)

--- a/lib/core/utils/file_upload_helper.dart
+++ b/lib/core/utils/file_upload_helper.dart
@@ -11,26 +11,29 @@ import 'package:http/http.dart' as http;
 ///
 /// This helper handles step 2. Steps 1 and 3 are handled by the caller.
 class FileUploadHelper {
-  /// Upload a file to a signed URL.
+  /// Upload a file to a signed URL using streaming to avoid
+  /// loading the entire file into memory.
   ///
   /// Returns true if the upload succeeded (HTTP 200).
-  /// Throws on network errors.
   static Future<bool> uploadToSignedUrl({
     required String signedUrl,
     required File file,
     required String contentType,
   }) async {
-    final bytes = await file.readAsBytes();
+    final request = http.StreamedRequest('PUT', Uri.parse(signedUrl));
+    request.headers.addAll({
+      'Content-Type': contentType,
+      'x-upsert': 'true',
+    });
+    request.contentLength = await file.length();
 
-    final response = await http.put(
-      Uri.parse(signedUrl),
-      headers: {
-        'Content-Type': contentType,
-        'x-upsert': 'true',
-      },
-      body: bytes,
-    );
+    file.openRead().listen(
+          request.sink.add,
+          onDone: request.sink.close,
+          onError: request.sink.addError,
+        );
 
+    final response = await request.send();
     return response.statusCode == 200;
   }
 

--- a/lib/data/datasources/remote/verification_remote_source.dart
+++ b/lib/data/datasources/remote/verification_remote_source.dart
@@ -1,0 +1,143 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/errors/exceptions.dart';
+import '../../../domain/entities/verification/verification_entities.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'verification_remote_source.g.dart';
+
+@riverpod
+VerificationRemoteSource verificationRemoteSource(Ref ref) {
+  return VerificationRemoteSourceImpl(ref.watch(dioProvider));
+}
+
+abstract class VerificationRemoteSource {
+  Future<VerificationRequest?> getStatus();
+  Future<VerificationRequest> submit({String? notes});
+  Future<VerificationRequest> resubmit({String? notes});
+  Future<List<VerificationDocument>> getDocuments();
+  Future<VerificationDocument> addDocument({
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+  });
+}
+
+class VerificationRemoteSourceImpl implements VerificationRemoteSource {
+  final Dio _dio;
+
+  VerificationRemoteSourceImpl(this._dio);
+
+  @override
+  Future<VerificationRequest?> getStatus() async {
+    try {
+      final response = await _dio.get('/api/verification/status');
+      final data = response.data['data'];
+      if (data == null) return null;
+      return VerificationRequest.fromJson(data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to get verification status',
+      );
+    }
+  }
+
+  @override
+  Future<VerificationRequest> submit({String? notes}) async {
+    try {
+      final response = await _dio.post(
+        '/api/verification/submit',
+        data: {'notes': notes},
+      );
+      return VerificationRequest.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 409) {
+        throw const ServerException(
+          message: 'A verification request is already pending',
+        );
+      }
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to submit verification',
+      );
+    }
+  }
+
+  @override
+  Future<VerificationRequest> resubmit({String? notes}) async {
+    try {
+      final response = await _dio.post(
+        '/api/verification/resubmit',
+        data: {'notes': notes},
+      );
+      return VerificationRequest.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to resubmit verification',
+      );
+    }
+  }
+
+  @override
+  Future<List<VerificationDocument>> getDocuments() async {
+    try {
+      final response = await _dio.get('/api/verification/documents');
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((d) =>
+              VerificationDocument.fromJson(d as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to list documents',
+      );
+    }
+  }
+
+  @override
+  Future<VerificationDocument> addDocument({
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/api/verification/documents',
+        data: {
+          'fileName': fileName,
+          'originalName': originalName,
+          'fileSize': fileSize,
+          'mimeType': mimeType,
+          'fileUrl': fileUrl,
+          'storagePath': storagePath,
+          'description': description,
+        },
+      );
+      return VerificationDocument.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to upload document',
+      );
+    }
+  }
+}

--- a/lib/data/datasources/remote/verification_remote_source.dart
+++ b/lib/data/datasources/remote/verification_remote_source.dart
@@ -27,6 +27,12 @@ abstract class VerificationRemoteSource {
     required String storagePath,
     String? description,
   });
+
+  /// Get a signed upload URL for a verification document.
+  Future<Map<String, dynamic>> getSignedUploadUrl({
+    required String fileName,
+    required String contentType,
+  });
 }
 
 class VerificationRemoteSourceImpl implements VerificationRemoteSource {
@@ -137,6 +143,29 @@ class VerificationRemoteSourceImpl implements VerificationRemoteSource {
       throw ServerException(
         message: e.response?.data?['error']?['message'] ??
             'Failed to upload document',
+      );
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>> getSignedUploadUrl({
+    required String fileName,
+    required String contentType,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/api/upload/document',
+        data: {
+          'fileName': fileName,
+          'contentType': contentType,
+          'bucket': 'verification-docs',
+        },
+      );
+      return response.data as Map<String, dynamic>;
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to get upload URL',
       );
     }
   }

--- a/lib/domain/entities/verification/verification_document.dart
+++ b/lib/domain/entities/verification/verification_document.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verification_document.freezed.dart';
+part 'verification_document.g.dart';
+
+@freezed
+class VerificationDocument with _$VerificationDocument {
+  const factory VerificationDocument({
+    required String id,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+    bool? isValid,
+    String? staffFeedback,
+    required String verificationId,
+    required DateTime uploadedAt,
+  }) = _VerificationDocument;
+
+  factory VerificationDocument.fromJson(Map<String, dynamic> json) =>
+      _$VerificationDocumentFromJson(json);
+}

--- a/lib/domain/entities/verification/verification_entities.dart
+++ b/lib/domain/entities/verification/verification_entities.dart
@@ -1,0 +1,6 @@
+/// Verification domain entities
+library;
+
+export 'verification_document.dart';
+export 'verification_request.dart';
+export 'verification_status.dart';

--- a/lib/domain/entities/verification/verification_request.dart
+++ b/lib/domain/entities/verification/verification_request.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'verification_document.dart';
+import 'verification_status.dart';
+
+part 'verification_request.freezed.dart';
+part 'verification_request.g.dart';
+
+@freezed
+class VerificationRequest with _$VerificationRequest {
+  const factory VerificationRequest({
+    required String id,
+    required VerificationStatus status,
+    required String consultantProfileId,
+    required DateTime submittedAt,
+    String? notes,
+    DateTime? reviewedAt,
+    String? reviewedById,
+    String? rejectionReason,
+    String? feedbackDetails,
+    @Default([]) List<VerificationDocument> documents,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _VerificationRequest;
+
+  const VerificationRequest._();
+
+  factory VerificationRequest.fromJson(Map<String, dynamic> json) =>
+      _$VerificationRequestFromJson(json);
+
+  bool get isPending => status.isPending;
+  bool get isApproved => status.isApproved;
+  bool get canResubmit => status.canResubmit;
+}

--- a/lib/domain/entities/verification/verification_status.dart
+++ b/lib/domain/entities/verification/verification_status.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// Verification status enum matching backend ProfileVerificationStatus.
+enum VerificationStatus {
+  @JsonValue('PENDING')
+  pending,
+  @JsonValue('APPROVED')
+  approved,
+  @JsonValue('REJECTED')
+  rejected,
+  @JsonValue('NEEDS_INFO')
+  needsInfo,
+  @JsonValue('SUPERSEDED')
+  superseded,
+}
+
+extension VerificationStatusX on VerificationStatus {
+  String get displayLabel => switch (this) {
+        VerificationStatus.pending => 'Pending Review',
+        VerificationStatus.approved => 'Approved',
+        VerificationStatus.rejected => 'Rejected',
+        VerificationStatus.needsInfo => 'More Info Needed',
+        VerificationStatus.superseded => 'Superseded',
+      };
+
+  bool get isPending => this == VerificationStatus.pending;
+  bool get isApproved => this == VerificationStatus.approved;
+  bool get canResubmit =>
+      this == VerificationStatus.rejected ||
+      this == VerificationStatus.needsInfo;
+}

--- a/lib/features/verification/providers/verification_provider.dart
+++ b/lib/features/verification/providers/verification_provider.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../../../data/datasources/remote/verification_remote_source.dart';
+import '../../../domain/entities/verification/verification_entities.dart';
+
+part 'verification_provider.g.dart';
+
+/// Provider for the current verification status
+@riverpod
+class VerificationState extends _$VerificationState {
+  @override
+  Future<VerificationRequest?> build() async {
+    final source = ref.read(verificationRemoteSourceProvider);
+    return source.getStatus();
+  }
+
+  /// Submit a new verification request
+  Future<void> submit({String? notes}) async {
+    state = const AsyncLoading();
+    try {
+      final source = ref.read(verificationRemoteSourceProvider);
+      final result = await source.submit(notes: notes);
+      state = AsyncData(result);
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationState.submit',
+      );
+      state = AsyncError(e, stack);
+    }
+  }
+
+  /// Resubmit after rejection
+  Future<void> resubmit({String? notes}) async {
+    state = const AsyncLoading();
+    try {
+      final source = ref.read(verificationRemoteSourceProvider);
+      final result = await source.resubmit(notes: notes);
+      state = AsyncData(result);
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationState.resubmit',
+      );
+      state = AsyncError(e, stack);
+    }
+  }
+
+  /// Refresh the verification status
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    try {
+      final source = ref.read(verificationRemoteSourceProvider);
+      final result = await source.getStatus();
+      state = AsyncData(result);
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+    }
+  }
+}
+
+/// Provider for verification documents
+@riverpod
+class VerificationDocuments extends _$VerificationDocuments {
+  @override
+  Future<List<VerificationDocument>> build() async {
+    final source = ref.read(verificationRemoteSourceProvider);
+    return source.getDocuments();
+  }
+
+  /// Add a document to the current verification
+  Future<void> addDocument({
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+  }) async {
+    try {
+      final source = ref.read(verificationRemoteSourceProvider);
+      final doc = await source.addDocument(
+        fileName: fileName,
+        originalName: originalName,
+        fileSize: fileSize,
+        mimeType: mimeType,
+        fileUrl: fileUrl,
+        storagePath: storagePath,
+        description: description,
+      );
+      final current = state.valueOrNull ?? [];
+      state = AsyncData([...current, doc]);
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationDocuments.addDocument',
+      );
+      rethrow;
+    }
+  }
+}

--- a/lib/features/verification/providers/verification_provider.dart
+++ b/lib/features/verification/providers/verification_provider.dart
@@ -58,6 +58,11 @@ class VerificationState extends _$VerificationState {
       final result = await source.getStatus();
       state = AsyncData(result);
     } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationState.refresh',
+      );
       state = AsyncError(e, stack);
     }
   }

--- a/lib/features/verification/screens/verification_status_screen.dart
+++ b/lib/features/verification/screens/verification_status_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 
 import '../../../domain/entities/verification/verification_entities.dart';
 import '../providers/verification_provider.dart';
@@ -222,6 +223,6 @@ class VerificationStatusScreen extends ConsumerWidget {
   }
 
   String _formatDate(DateTime date) {
-    return '${date.day}/${date.month}/${date.year}';
+    return DateFormat.yMMMd().format(date);
   }
 }

--- a/lib/features/verification/screens/verification_status_screen.dart
+++ b/lib/features/verification/screens/verification_status_screen.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../domain/entities/verification/verification_entities.dart';
+import '../providers/verification_provider.dart';
+import '../widgets/document_upload_card.dart';
+import '../widgets/verification_status_badge.dart';
+
+class VerificationStatusScreen extends ConsumerWidget {
+  const VerificationStatusScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final verificationAsync = ref.watch(verificationStateProvider);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verification Status')),
+      body: verificationAsync.when(
+        data: (verification) {
+          if (verification == null) {
+            return _buildNoVerification(context);
+          }
+          return _buildVerificationDetails(
+            context,
+            ref,
+            verification,
+            theme,
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Failed to load status: $error'),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () =>
+                    ref.read(verificationStateProvider.notifier).refresh(),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoVerification(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.verified_user, size: 64, color: Colors.grey),
+            const SizedBox(height: 16),
+            Text(
+              'No Verification Submitted',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Submit your verification to get your profile verified '
+              'and build trust with consultees.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () => context.push('/verification/submit'),
+              icon: const Icon(Icons.upload_file),
+              label: const Text('Submit Verification'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVerificationDetails(
+    BuildContext context,
+    WidgetRef ref,
+    VerificationRequest verification,
+    ThemeData theme,
+  ) {
+    final documentsAsync = ref.watch(verificationDocumentsProvider);
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(verificationStateProvider.notifier).refresh(),
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Status card
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Verification',
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      VerificationStatusBadge(status: verification.status),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _infoRow('Submitted', _formatDate(verification.submittedAt)),
+                  if (verification.notes != null)
+                    _infoRow('Notes', verification.notes!),
+                  if (verification.reviewedAt != null)
+                    _infoRow(
+                      'Reviewed',
+                      _formatDate(verification.reviewedAt!),
+                    ),
+                ],
+              ),
+            ),
+          ),
+
+          // Rejection feedback
+          if (verification.rejectionReason != null) ...[
+            const SizedBox(height: 16),
+            Card(
+              color: Colors.red.shade50,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Feedback',
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: Colors.red.shade700,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(verification.rejectionReason!),
+                    if (verification.feedbackDetails != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        verification.feedbackDetails!,
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+
+          // Documents
+          const SizedBox(height: 16),
+          Text('Documents', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          documentsAsync.when(
+            data: (documents) {
+              if (documents.isEmpty) {
+                return const Card(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text('No documents uploaded yet.'),
+                  ),
+                );
+              }
+              return Column(
+                children: documents
+                    .map((doc) => DocumentUploadCard(document: doc))
+                    .toList(),
+              );
+            },
+            loading: () =>
+                const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Text('Failed to load documents: $e'),
+          ),
+
+          // Actions
+          const SizedBox(height: 24),
+          if (verification.isPending)
+            OutlinedButton.icon(
+              onPressed: () => context.push('/verification/submit'),
+              icon: const Icon(Icons.add),
+              label: const Text('Add Documents'),
+            ),
+          if (verification.canResubmit)
+            FilledButton.icon(
+              onPressed: () => context.push('/verification/submit'),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Resubmit Verification'),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _infoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontWeight: FontWeight.w500,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          Expanded(child: Text(value)),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day}/${date.month}/${date.year}';
+  }
+}

--- a/lib/features/verification/screens/verification_submit_screen.dart
+++ b/lib/features/verification/screens/verification_submit_screen.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+
+import '../../../core/config/env_config.dart';
+import '../../../core/network/dio_client.dart' show AuthInterceptor;
+import '../../../core/utils/file_upload_helper.dart';
+import '../../../core/utils/sentry_logger.dart';
+import '../providers/verification_provider.dart';
+
+class VerificationSubmitScreen extends ConsumerStatefulWidget {
+  const VerificationSubmitScreen({super.key});
+
+  @override
+  ConsumerState<VerificationSubmitScreen> createState() =>
+      _VerificationSubmitScreenState();
+}
+
+class _VerificationSubmitScreenState
+    extends ConsumerState<VerificationSubmitScreen> {
+  final _notesController = TextEditingController();
+  final _uploadedFiles = <_UploadedFile>[];
+  bool _isSubmitting = false;
+  bool _isUploading = false;
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Submit Verification')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Upload documents to verify your profile',
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Upload your ID, degree certificates, professional '
+            'certifications, or any other relevant documents.',
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 24),
+
+          // Notes field
+          TextField(
+            controller: _notesController,
+            decoration: const InputDecoration(
+              labelText: 'Notes (optional)',
+              hintText: 'Any additional information for reviewers...',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+          const SizedBox(height: 24),
+
+          // Upload button
+          OutlinedButton.icon(
+            onPressed: _isUploading ? null : _pickAndUploadFile,
+            icon: _isUploading
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.upload_file),
+            label: Text(_isUploading ? 'Uploading...' : 'Add Document'),
+          ),
+          const SizedBox(height: 16),
+
+          // Uploaded files list
+          if (_uploadedFiles.isNotEmpty) ...[
+            Text('Uploaded Documents', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            ..._uploadedFiles.map(
+              (f) => Card(
+                child: ListTile(
+                  leading: const Icon(Icons.insert_drive_file),
+                  title: Text(
+                    f.originalName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(f.description ?? 'Document'),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () =>
+                        setState(() => _uploadedFiles.remove(f)),
+                  ),
+                ),
+              ),
+            ),
+          ],
+
+          const SizedBox(height: 32),
+
+          // Submit button
+          FilledButton(
+            onPressed: _isSubmitting ? null : _submit,
+            child: _isSubmitting
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Text('Submit Verification'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickAndUploadFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf', 'jpg', 'jpeg', 'png', 'doc', 'docx'],
+    );
+
+    if (result == null || result.files.isEmpty) return;
+
+    final file = result.files.first;
+    if (file.path == null) return;
+
+    setState(() => _isUploading = true);
+
+    try {
+      // Get description from user
+      final description = await _askDescription();
+
+      // Get signed URL from backend
+      final token = await AuthInterceptor.getToken();
+      final signedUrlResponse = await http.post(
+        Uri.parse('${EnvConfig.apiBaseUrl}/api/upload/document'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({
+          'fileName': file.name,
+          'contentType': _getMimeType(file.extension ?? 'bin'),
+          'bucket': 'verification-docs',
+        }),
+      );
+
+      if (signedUrlResponse.statusCode != 200) {
+        throw Exception('Failed to get upload URL');
+      }
+
+      final urlData =
+          jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
+      final signedUrl = urlData['signedUrl'] as String;
+      final publicUrl = urlData['publicUrl'] as String;
+      final storagePath = urlData['path'] as String;
+
+      // Upload file to Supabase
+      final uploaded = await FileUploadHelper.uploadToSignedUrl(
+        signedUrl: signedUrl,
+        file: File(file.path!),
+        contentType: _getMimeType(file.extension ?? 'bin'),
+      );
+
+      if (!uploaded) throw Exception('Upload failed');
+
+      setState(() {
+        _uploadedFiles.add(_UploadedFile(
+          fileName: file.name,
+          originalName: file.name,
+          fileSize: file.size,
+          mimeType: _getMimeType(file.extension ?? 'bin'),
+          fileUrl: publicUrl,
+          storagePath: storagePath,
+          description: description,
+        ));
+      });
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationSubmit._pickAndUploadFile',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to upload file')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isUploading = false);
+    }
+  }
+
+  Future<String?> _askDescription() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Document Type'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: 'e.g., Government ID, Degree Certificate',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Skip'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    return result?.isNotEmpty == true ? result : null;
+  }
+
+  Future<void> _submit() async {
+    setState(() => _isSubmitting = true);
+
+    try {
+      // Submit or resubmit verification
+      final notifier = ref.read(verificationStateProvider.notifier);
+      final currentVerification =
+          ref.read(verificationStateProvider).valueOrNull;
+
+      if (currentVerification != null && currentVerification.canResubmit) {
+        await notifier.resubmit(notes: _notesController.text);
+      } else {
+        await notifier.submit(notes: _notesController.text);
+      }
+
+      // Add documents to the verification
+      final docsNotifier =
+          ref.read(verificationDocumentsProvider.notifier);
+      for (final file in _uploadedFiles) {
+        await docsNotifier.addDocument(
+          fileName: file.fileName,
+          originalName: file.originalName,
+          fileSize: file.fileSize,
+          mimeType: file.mimeType,
+          fileUrl: file.fileUrl,
+          storagePath: file.storagePath,
+          description: file.description,
+        );
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Verification submitted successfully'),
+          ),
+        );
+        context.pop();
+      }
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'VerificationSubmit._submit',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to submit: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  String _getMimeType(String ext) => switch (ext.toLowerCase()) {
+        'pdf' => 'application/pdf',
+        'jpg' || 'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'doc' => 'application/msword',
+        'docx' =>
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        _ => 'application/octet-stream',
+      };
+}
+
+class _UploadedFile {
+  final String fileName;
+  final String originalName;
+  final int fileSize;
+  final String mimeType;
+  final String fileUrl;
+  final String storagePath;
+  final String? description;
+
+  _UploadedFile({
+    required this.fileName,
+    required this.originalName,
+    required this.fileSize,
+    required this.mimeType,
+    required this.fileUrl,
+    required this.storagePath,
+    this.description,
+  });
+}

--- a/lib/features/verification/screens/verification_submit_screen.dart
+++ b/lib/features/verification/screens/verification_submit_screen.dart
@@ -1,16 +1,13 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:http/http.dart' as http;
 
-import '../../../core/config/env_config.dart';
-import '../../../core/network/dio_client.dart' show AuthInterceptor;
 import '../../../core/utils/file_upload_helper.dart';
 import '../../../core/utils/sentry_logger.dart';
+import '../../../data/datasources/remote/verification_remote_source.dart';
 import '../providers/verification_provider.dart';
 
 class VerificationSubmitScreen extends ConsumerStatefulWidget {
@@ -143,27 +140,12 @@ class _VerificationSubmitScreenState
       // Get description from user
       final description = await _askDescription();
 
-      // Get signed URL from backend
-      final token = await AuthInterceptor.getToken();
-      final signedUrlResponse = await http.post(
-        Uri.parse('${EnvConfig.apiBaseUrl}/api/upload/document'),
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer $token',
-        },
-        body: jsonEncode({
-          'fileName': file.name,
-          'contentType': _getMimeType(file.extension ?? 'bin'),
-          'bucket': 'verification-docs',
-        }),
+      // Get signed URL from backend via remote source
+      final source = ref.read(verificationRemoteSourceProvider);
+      final urlData = await source.getSignedUploadUrl(
+        fileName: file.name,
+        contentType: _getMimeType(file.extension ?? 'bin'),
       );
-
-      if (signedUrlResponse.statusCode != 200) {
-        throw Exception('Failed to get upload URL');
-      }
-
-      final urlData =
-          jsonDecode(signedUrlResponse.body) as Map<String, dynamic>;
       final signedUrl = urlData['signedUrl'] as String;
       final publicUrl = urlData['publicUrl'] as String;
       final storagePath = urlData['path'] as String;

--- a/lib/features/verification/widgets/document_upload_card.dart
+++ b/lib/features/verification/widgets/document_upload_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/entities/verification/verification_document.dart';
+
+class DocumentUploadCard extends StatelessWidget {
+  const DocumentUploadCard({
+    required this.document,
+    super.key,
+  });
+
+  final VerificationDocument document;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: ListTile(
+        leading: Icon(
+          _iconForMimeType(document.mimeType),
+          color: theme.colorScheme.primary,
+        ),
+        title: Text(
+          document.originalName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          '${_formatFileSize(document.fileSize)}'
+          '${document.description != null ? ' - ${document.description}' : ''}',
+          style: theme.textTheme.bodySmall,
+        ),
+        trailing: _buildValidityIndicator(document.isValid),
+      ),
+    );
+  }
+
+  IconData _iconForMimeType(String mimeType) {
+    if (mimeType.startsWith('image/')) return Icons.image;
+    if (mimeType == 'application/pdf') return Icons.picture_as_pdf;
+    return Icons.insert_drive_file;
+  }
+
+  String _formatFileSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  Widget? _buildValidityIndicator(bool? isValid) {
+    if (isValid == null) return null;
+    return Icon(
+      isValid ? Icons.check_circle : Icons.error,
+      color: isValid ? Colors.green : Colors.red,
+      size: 20,
+    );
+  }
+}

--- a/lib/features/verification/widgets/verification_status_badge.dart
+++ b/lib/features/verification/widgets/verification_status_badge.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/entities/verification/verification_status.dart';
+
+class VerificationStatusBadge extends StatelessWidget {
+  const VerificationStatusBadge({
+    required this.status,
+    super.key,
+  });
+
+  final VerificationStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final (color, icon) = switch (status) {
+      VerificationStatus.pending => (Colors.orange, Icons.hourglass_top),
+      VerificationStatus.approved => (Colors.green, Icons.verified),
+      VerificationStatus.rejected => (Colors.red, Icons.cancel),
+      VerificationStatus.needsInfo => (Colors.blue, Icons.info),
+      VerificationStatus.superseded => (Colors.grey, Icons.history),
+    };
+
+    return Chip(
+      avatar: Icon(icon, size: 16, color: color),
+      label: Text(
+        status.displayLabel,
+        style: TextStyle(color: color, fontSize: 12),
+      ),
+      backgroundColor: color.withValues(alpha: 0.1),
+      side: BorderSide(color: color.withValues(alpha: 0.3)),
+      padding: EdgeInsets.zero,
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -522,13 +522,13 @@ packages:
     source: hosted
     version: "7.0.1"
   file_picker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: file_picker
-      sha256: d974b6ba2606371ac71dd94254beefb6fa81185bde0b59bdc1df09885da85fde
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.8"
+    version: "10.3.10"
   file_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ dependencies:
   flutter_local_notifications: ^17.2.3
   flutter_web_auth_2: ^4.1.0
   http: ^1.6.0
+  file_picker: ^10.3.10
 
 dev_dependencies:
   sentry_dart_plugin: ^3.2.0


### PR DESCRIPTION
## Summary
Full consultant verification UI following clean architecture (domain -> data -> feature layers):
- **Domain entities**: `VerificationRequest`, `VerificationDocument`, `VerificationStatus` (Freezed)
- **Remote source**: Dio-based `VerificationRemoteSource` calling `/api/verification/*` endpoints
- **Providers**: `VerificationState` (submit/resubmit/refresh), `VerificationDocuments` (list/add)
- **Screens**: Status screen (view verification + feedback + documents), Submit screen (file picker + Supabase upload)
- **Widgets**: `VerificationStatusBadge` (color-coded), `DocumentUploadCard` (file info + validity)
- **Routes**: `/verification` and `/verification/submit`

## New Files (11)
| File | Layer |
|------|-------|
| `lib/domain/entities/verification/*.dart` | Domain (4 files) |
| `lib/data/datasources/remote/verification_remote_source.dart` | Data |
| `lib/features/verification/providers/verification_provider.dart` | Feature |
| `lib/features/verification/screens/verification_status_screen.dart` | Feature |
| `lib/features/verification/screens/verification_submit_screen.dart` | Feature |
| `lib/features/verification/widgets/*.dart` | Feature (2 files) |

## Dependencies
- Added `file_picker` for document selection

## Test plan
- [x] `dart analyze` clean (0 errors)
- [x] Build runner generates all Freezed + Riverpod code
- [ ] Manual test: navigate to /verification shows status screen
- [ ] Manual test: submit verification with document uploads
- [ ] Manual test: view rejection feedback and resubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)