### PR TITLE
feature: add professional background to consultant onboarding

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -38,9 +38,9 @@
 | Personal info (name, phone, DOB, gender, etc.) | ✅ | ✅ |
 | Consultant profile (headline, description, domains) | ✅ | ✅ |
 | Consultee profile (career stage, preferences) | ✅ | ✅ |
-| Professional background — Work experience | ✅ | ❌ |
-| Professional background — Education | ✅ | ❌ |
-| Professional background — Certifications | ✅ | ❌ |
+| Professional background — Work experience | ✅ | ✅ |
+| Professional background — Education | ✅ | ✅ |
+| Professional background — Certifications | ✅ | ✅ |
 | Professional background — Achievements | ✅ | ❌ |
 | Verification document upload during onboarding | ✅ | ❌ |
 | Review step with navigation back to specific steps | ✅ | ❌ |

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -1,0 +1,382 @@
+# Feature Parity: Web App vs Mobile App
+
+> Last updated: 2026-03-24
+>
+> Legend: ✅ Implemented | ❌ Not Implemented | 🟡 Partial | 🔵 Backend Only (no UI)
+
+---
+
+## Authentication & Sessions
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Email/password sign-up | ✅ | ✅ |
+| Email/password sign-in | ✅ | ✅ |
+| Google OAuth | ✅ | ✅ |
+| GitHub OAuth | ✅ | ✅ |
+| Facebook OAuth | ✅ | ❌ |
+| Apple Sign-In | ❌ | ✅ |
+| Forgot password | ✅ | ✅ |
+| Reset password | ✅ | ✅ |
+| Change password | ✅ | ✅ |
+| Set password (OAuth users) | ✅ | ✅ |
+| Email verification | ✅ | ✅ |
+| Session management (list/revoke) | ✅ | ✅ |
+| Delete account | ✅ | ✅ |
+| Server-side session invalidation on sign-out | ✅ | ✅ |
+| CookiePreference creation on signup | ✅ | ✅ |
+| NotificationPreference creation on signup | ✅ | ✅ |
+| Account linking (trusted providers) | ✅ | ❌ |
+| Novu subscriber sync on signup | ✅ | ❌ |
+
+## Onboarding
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Role selection (Consultant/Consultee) | ✅ | ✅ |
+| Staff role onboarding | ✅ | ❌ |
+| Personal info (name, phone, DOB, gender, etc.) | ✅ | ✅ |
+| Consultant profile (headline, description, domains) | ✅ | ✅ |
+| Consultee profile (career stage, preferences) | ✅ | ✅ |
+| Professional background — Work experience | ✅ | ❌ |
+| Professional background — Education | ✅ | ❌ |
+| Professional background — Certifications | ✅ | ❌ |
+| Professional background — Achievements | ✅ | ❌ |
+| Verification document upload during onboarding | ✅ | ❌ |
+| Review step with navigation back to specific steps | ✅ | ❌ |
+| Terms & privacy consent | ✅ | ✅ |
+| Profile image upload | ✅ | ✅ |
+| Profile display image upload | ✅ | ✅ |
+
+## User Profiles
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| View own profile | ✅ | ✅ |
+| Edit profile (name, phone, bio, etc.) | ✅ | ✅ |
+| GET /api/user/:id route | ✅ | ✅ |
+| PUT /api/user/:id route | ✅ | ✅ |
+| Profile image upload (dedicated route) | ✅ | ✅ |
+| Profile display image upload (dedicated route) | ✅ | ✅ |
+| All User fields (termsAcceptedAt, privacyAcceptedAt, etc.) | ✅ | ✅ |
+
+## Explore & Discovery
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Browse consultants | ✅ | ✅ |
+| Consultant profile page | ✅ | ✅ |
+| Consultant reviews | ✅ | ✅ |
+| Consultant availability | ✅ | ✅ |
+| Browse programs (webinars/classes) | ✅ | ✅ |
+| Explore activities/hackathons | ✅ | ❌ |
+| Community page | ✅ | ❌ |
+| Search consultants | ✅ | 🟡 |
+
+## Booking & Scheduling
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Create consultation booking | ✅ | ✅ |
+| View appointments | ✅ | ✅ |
+| Cancel appointment | ✅ | ✅ |
+| Reschedule appointment | ✅ | ✅ |
+| Weekly availability management | ✅ | ✅ |
+| Custom availability slots | ✅ | ✅ |
+| Subscription booking | ✅ | ✅ |
+| Webinar enrollment | ✅ | ✅ |
+| Class enrollment | ✅ | ✅ |
+| Slot allocation/validation | ✅ | 🟡 |
+| Participant management | ✅ | ❌ |
+| Schedule type switching check | ✅ | ❌ |
+| Approval workflow (request-for-approval) | ✅ | 🟡 |
+
+## Plans & Pricing
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Consultation plans (CRUD) | ✅ | 🟡 |
+| Subscription plans (CRUD) | ✅ | 🟡 |
+| Webinar plans (CRUD + materials) | ✅ | 🟡 |
+| Class plans (CRUD + materials + contents) | ✅ | 🟡 |
+| Plan materials upload | ✅ | ❌ |
+| Plan image upload | ✅ | ❌ |
+| Plan recordings management | ✅ | ❌ |
+
+## Checkout & Payments
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Checkout flow (create session) | ✅ | ✅ |
+| Payment verification | ✅ | ✅ |
+| Stripe integration | ✅ | ✅ |
+| Razorpay integration | ✅ | ✅ |
+| Lemon Squeezy integration | ✅ | ❌ |
+| Xflow integration | ✅ | ❌ |
+| Discount code validation | ✅ | 🟡 |
+| Payment recovery/retry | ✅ | ❌ |
+| Stripe webhooks | ✅ | ✅ |
+| Razorpay webhooks | ✅ | ✅ |
+| Lemon Squeezy webhooks | ✅ | ❌ |
+| Refund management | ✅ | ✅ |
+| Dispute management | ✅ | ✅ |
+| Invoice generation | ✅ | 🔵 |
+
+## Payouts & Earnings
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Consultant earnings dashboard | ✅ | 🟡 |
+| Payout account management (CRUD) | ✅ | ❌ |
+| Payout account types (Bank, UPI, Stripe Connect) | ✅ | ❌ |
+| Set default payout account | ✅ | ❌ |
+| Payout processing | ✅ | ❌ |
+| Payout batch creation | ✅ | ❌ |
+| Consultant tax info (PAN, GSTIN) | ✅ | ❌ |
+| TDS records | ✅ | ❌ |
+| Earnings release workflow | ✅ | ❌ |
+| Revenue split tracking | ✅ | ❌ |
+
+## Stream / Meetings
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Video meetings (Stream SDK) | ✅ | ✅ |
+| Start/end meeting | ✅ | ✅ |
+| Get meeting details | ✅ | ✅ |
+| Stream token generation | ✅ | ✅ |
+| Recording — start/stop | ✅ | ❌ |
+| Recording — view/manage | ✅ | ❌ |
+| Recording — transfer (Stream → Supabase) | ✅ | ❌ |
+| Recording — sync metadata | ✅ | ❌ |
+| Recording expiration tracking | ✅ | ❌ |
+| Meeting access validation | ✅ | ❌ |
+
+## Chat & Messaging
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Stream Chat integration | ✅ | ✅ |
+| Chat token generation | ✅ | ✅ |
+| Create group channels | ✅ | ✅ |
+| Add/remove members | ✅ | ✅ |
+| Set member roles | ✅ | ✅ |
+| Archive/unarchive channels | ✅ | ✅ |
+| Block users | ✅ | ❌ |
+| Search consultees in chat | ✅ | ❌ |
+
+## Trials
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Request trial session | ✅ | ❌ |
+| Accept/reject trial | ✅ | ❌ |
+| Check trial eligibility | ✅ | ❌ |
+| Trial statistics | ✅ | ❌ |
+| Trial → subscription conversion | ✅ | ❌ |
+
+## Waitlist
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Join waitlist | ✅ | ❌ |
+| Leave waitlist | ✅ | ❌ |
+| Respond to waitlist notification | ✅ | ❌ |
+| Waitlist statistics | ✅ | ❌ |
+| Waitlist position tracking | ✅ | ❌ |
+
+## Document Review
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Upload appointment documents | ✅ | ❌ |
+| Download documents | ✅ | ❌ |
+| Consultant review (approve/reject) | ✅ | ❌ |
+| Consultant response document | ✅ | ❌ |
+| Document review status tracking | ✅ | ❌ |
+
+## Consultant Verification
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Submit verification | ✅ | ✅ |
+| Check verification status | ✅ | ✅ |
+| Upload verification documents | ✅ | ✅ |
+| Resubmit after rejection | ✅ | ✅ |
+| Staff verification review | ✅ | ❌ |
+
+## Collaborations
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Create collaboration invitation | ✅ | ✅ |
+| Respond to collaboration | ✅ | ✅ |
+| Per-plan collaborator management (webinar) | ✅ | ❌ |
+| Per-plan collaborator management (class) | ✅ | ❌ |
+| Revenue split configuration | ✅ | ❌ |
+| Collaborator availability check | ✅ | ❌ |
+
+## Referrals & Credits
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Get/generate referral code | ✅ | ✅ |
+| Apply referral code | ✅ | ✅ |
+| Get available credits | ✅ | ✅ |
+| Customize referral code | ✅ | ❌ |
+| Check code validity | ✅ | ❌ |
+| Referral landing page (/r/code) | ✅ | ❌ |
+| Credit usage tracking | ✅ | ❌ |
+
+## Support & Feedback
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Create support ticket | ✅ | ✅ |
+| List support tickets | ✅ | ✅ |
+| Ticket detail with responses | ✅ | ✅ |
+| Add response to ticket | ✅ | ✅ |
+| Ticket attachments | ✅ | ❌ |
+| Submit feedback | ✅ | ✅ |
+| Submit review | ✅ | ✅ |
+
+## Announcements
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| View active announcements | ✅ | ❌ |
+| Dismissible announcement banner | ✅ | ❌ |
+| Admin: create/manage announcements | ✅ | ❌ |
+
+## Maintenance Mode
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Maintenance status check | ✅ | ❌ |
+| Maintenance mode screen | ✅ | ❌ |
+| Admin: toggle maintenance | ✅ | ❌ |
+| Maintenance bypass (VIP secret) | ✅ | ❌ |
+
+## Notifications
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Notification preferences (channel/category) | ✅ | 🔵 |
+| Quiet hours | ✅ | 🔵 |
+| Novu integration (multi-channel) | ✅ | ❌ |
+| Push notifications (Firebase) | ✅ | 🟡 |
+| Email notifications (Resend) | ✅ | ❌ |
+| Newsletter subscribe/unsubscribe | ✅ | ❌ |
+
+## Content Management
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Domains (read) | ✅ | ✅ |
+| Subdomains (read) | ✅ | ❌ |
+| Tags (read) | ✅ | ❌ |
+| Topics (read) | ✅ | ❌ |
+
+## Admin Dashboard
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Analytics & statistics | ✅ | ❌ |
+| User management (CRUD) | ✅ | ❌ |
+| Payment management | ✅ | ❌ |
+| Payout management | ✅ | ❌ |
+| Dispute management | ✅ | ❌ |
+| Refund management | ✅ | ❌ |
+| Invoice management | ✅ | ❌ |
+| Subscription management | ✅ | ❌ |
+| Waitlist management | ✅ | ❌ |
+| Verification review | ✅ | ❌ |
+| Announcement management | ✅ | ❌ |
+| Maintenance toggle | ✅ | ❌ |
+| System jobs | ✅ | ❌ |
+| Newsletter sending | ✅ | ❌ |
+| TDS management | ✅ | ❌ |
+| Approval payments | ✅ | ❌ |
+| Cancellation analytics | ✅ | ❌ |
+
+## Staff Dashboard
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Metrics & statistics | ✅ | ❌ |
+| Support ticket management | ✅ | ❌ |
+| Moderation — reports | ✅ | ❌ |
+| Moderation — report actions | ✅ | ❌ |
+| Moderation — review moderation | ✅ | ❌ |
+| Moderation — profile verification | ✅ | ❌ |
+| Moderation — statistics | ✅ | ❌ |
+| Feedback review | ✅ | ❌ |
+| Invoice management | ✅ | ❌ |
+| Payout tracking | ✅ | ❌ |
+| System jobs | ✅ | ❌ |
+| Appointment management | ✅ | ❌ |
+
+## Cleanup / Cron Jobs (Web-only by design)
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Abandoned payment recovery | ✅ | N/A |
+| Stale request expiry | ✅ | N/A |
+| Recording transfer/expiry | ✅ | N/A |
+| Payout batch creation/processing | ✅ | N/A |
+| Earnings release | ✅ | N/A |
+| Dispute reconciliation | ✅ | N/A |
+| Payment/refund reconciliation | ✅ | N/A |
+| Session reconciliation | ✅ | N/A |
+| Document storage reconciliation | ✅ | N/A |
+| Auth token cleanup | ✅ | N/A |
+| Auto-complete appointments | ✅ | N/A |
+| Slot availability reconciliation | ✅ | N/A |
+| Stream sync | ✅ | N/A |
+| Deactivate expired discounts | ✅ | N/A |
+
+## Static / Marketing Pages
+
+| Feature | Web | Mobile |
+|---------|-----|--------|
+| Homepage | ✅ | N/A |
+| About page | ✅ | N/A |
+| Contact page | ✅ | N/A |
+| Pricing page | ✅ | N/A |
+| Privacy policy | ✅ | N/A |
+| Terms of service | ✅ | N/A |
+| Refund policy | ✅ | N/A |
+| Blog | ✅ | N/A |
+| Use case pages | ✅ | N/A |
+
+---
+
+## Summary
+
+| Category | Web | Mobile | Gap |
+|----------|-----|--------|-----|
+| Auth & Sessions | 18 | 16 | 2 missing |
+| Onboarding | 14 | 8 | 6 missing |
+| Profiles | 7 | 7 | Parity ✅ |
+| Explore | 6 | 4 | 2 missing |
+| Booking & Scheduling | 13 | 9 | 4 missing |
+| Plans & Pricing | 7 | 0 full | 7 partial/missing |
+| Checkout & Payments | 14 | 9 | 5 missing |
+| Payouts & Earnings | 10 | 0 | **10 missing** |
+| Stream / Meetings | 10 | 4 | 6 missing |
+| Chat | 8 | 6 | 2 missing |
+| Trials | 5 | 0 | **5 missing** |
+| Waitlist | 5 | 0 | **5 missing** |
+| Document Review | 5 | 0 | **5 missing** |
+| Verification | 5 | 4 | 1 missing |
+| Collaborations | 6 | 2 | 4 missing |
+| Referrals | 7 | 3 | 4 missing |
+| Support & Feedback | 7 | 6 | 1 missing |
+| Announcements | 3 | 0 | **3 missing** |
+| Maintenance | 4 | 0 | **4 missing** |
+| Notifications | 6 | 1 | 5 missing |
+| Content Management | 4 | 1 | 3 missing |
+| Admin Dashboard | 17 | 0 | **N/A (web-only)** |
+| Staff Dashboard | 12 | 0 | **12 missing** |
+
+**Total features: ~186 (web) vs ~80 (mobile) — ~57% gap**

--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -2111,5 +2111,134 @@ SchemaRegistry buildSchemaRegistry() {
     },
   ));
 
+  // WorkExperience (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'WorkExperience',
+    tableName: 'WorkExperience',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'company': const FieldInfo(
+          name: 'company', columnName: 'company', type: 'String'),
+      'companyDomain': const FieldInfo(
+          name: 'companyDomain',
+          columnName: 'companyDomain',
+          type: 'String'),
+      'title': const FieldInfo(
+          name: 'title', columnName: 'title', type: 'String'),
+      'location': const FieldInfo(
+          name: 'location', columnName: 'location', type: 'String'),
+      'startDate': const FieldInfo(
+          name: 'startDate', columnName: 'startDate', type: 'DateTime'),
+      'endDate': const FieldInfo(
+          name: 'endDate', columnName: 'endDate', type: 'DateTime'),
+      'isCurrent': const FieldInfo(
+          name: 'isCurrent', columnName: 'isCurrent', type: 'Boolean'),
+      'description': const FieldInfo(
+          name: 'description', columnName: 'description', type: 'String'),
+      'userId': const FieldInfo(
+          name: 'userId', columnName: 'userId', type: 'String'),
+      'createdAt': const FieldInfo(
+          name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'user': RelationInfo.oneToOne(
+        name: 'user',
+        targetModel: 'users',
+        foreignKey: 'userId',
+        isOwner: true,
+      ),
+    },
+  ));
+
+  // Certification (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'Certification',
+    tableName: 'Certification',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'name': const FieldInfo(
+          name: 'name', columnName: 'name', type: 'String'),
+      'issuingOrganization': const FieldInfo(
+          name: 'issuingOrganization',
+          columnName: 'issuingOrganization',
+          type: 'String'),
+      'issueDate': const FieldInfo(
+          name: 'issueDate', columnName: 'issueDate', type: 'DateTime'),
+      'expiryDate': const FieldInfo(
+          name: 'expiryDate', columnName: 'expiryDate', type: 'DateTime'),
+      'credentialId': const FieldInfo(
+          name: 'credentialId',
+          columnName: 'credentialId',
+          type: 'String'),
+      'credentialUrl': const FieldInfo(
+          name: 'credentialUrl',
+          columnName: 'credentialUrl',
+          type: 'String'),
+      'userId': const FieldInfo(
+          name: 'userId', columnName: 'userId', type: 'String'),
+      'createdAt': const FieldInfo(
+          name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'user': RelationInfo.oneToOne(
+        name: 'user',
+        targetModel: 'users',
+        foreignKey: 'userId',
+        isOwner: true,
+      ),
+    },
+  ));
+
+  // Education (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'Education',
+    tableName: 'Education',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'institution': const FieldInfo(
+          name: 'institution',
+          columnName: 'institution',
+          type: 'String'),
+      'institutionDomain': const FieldInfo(
+          name: 'institutionDomain',
+          columnName: 'institutionDomain',
+          type: 'String'),
+      'degree': const FieldInfo(
+          name: 'degree', columnName: 'degree', type: 'String'),
+      'fieldOfStudy': const FieldInfo(
+          name: 'fieldOfStudy',
+          columnName: 'fieldOfStudy',
+          type: 'String'),
+      'startYear': const FieldInfo(
+          name: 'startYear', columnName: 'startYear', type: 'Int'),
+      'endYear': const FieldInfo(
+          name: 'endYear', columnName: 'endYear', type: 'Int'),
+      'grade': const FieldInfo(
+          name: 'grade', columnName: 'grade', type: 'String'),
+      'activities': const FieldInfo(
+          name: 'activities', columnName: 'activities', type: 'String'),
+      'description': const FieldInfo(
+          name: 'description', columnName: 'description', type: 'String'),
+      'userId': const FieldInfo(
+          name: 'userId', columnName: 'userId', type: 'String'),
+      'createdAt': const FieldInfo(
+          name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'user': RelationInfo.oneToOne(
+        name: 'user',
+        targetModel: 'users',
+        foreignKey: 'userId',
+        isOwner: true,
+      ),
+    },
+  ));
+
   return schema;
 }

--- a/backend/lib/utils/professional_background_utils.dart
+++ b/backend/lib/utils/professional_background_utils.dart
@@ -1,0 +1,125 @@
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Shared utility for creating professional background records
+/// within a database transaction.
+///
+/// Used by both onboarding submit and the professional-background PUT route.
+class ProfessionalBackgroundUtils {
+  /// Create work experience, education, and certification records
+  /// for a user within a transaction.
+  static Future<void> createRecords({
+    required String userId,
+    required TransactionExecutor txn,
+    List<dynamic>? workExperiences,
+    List<dynamic>? education,
+    List<dynamic>? certifications,
+  }) async {
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    if (workExperiences != null) {
+      for (final we in workExperiences) {
+        final item = we as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('WorkExperience')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'company': item['company'],
+          'companyDomain': item['companyDomain'],
+          'title': item['title'],
+          'location': item['location'],
+          'startDate': item['startDate'],
+          'endDate': item['endDate'],
+          'isCurrent': item['isCurrent'] ?? false,
+          'description': item['description'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+    }
+
+    if (education != null) {
+      for (final edu in education) {
+        final item = edu as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('Education')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'institution': item['institution'],
+          'institutionDomain': item['institutionDomain'],
+          'degree': item['degree'],
+          'fieldOfStudy': item['fieldOfStudy'],
+          'startYear': item['startYear'],
+          'endYear': item['endYear'],
+          'grade': item['grade'],
+          'activities': item['activities'],
+          'description': item['description'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+    }
+
+    if (certifications != null) {
+      for (final cert in certifications) {
+        final item = cert as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('Certification')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'name': item['name'],
+          'issuingOrganization': item['issuingOrganization'],
+          'issueDate': item['issueDate'],
+          'expiryDate': item['expiryDate'],
+          'credentialId': item['credentialId'],
+          'credentialUrl': item['credentialUrl'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+    }
+  }
+
+  /// Delete all professional background records for a user
+  /// within a transaction.
+  static Future<void> deleteRecords({
+    required String userId,
+    required TransactionExecutor txn,
+  }) async {
+    for (final model in [
+      'WorkExperience',
+      'Education',
+      'Certification',
+    ]) {
+      final query = JsonQueryBuilder()
+          .model(model)
+          .action(QueryAction.deleteMany)
+          .where({'userId': userId})
+          .build();
+      await txn.executeMutation(query);
+    }
+  }
+
+  /// Replace all professional background records (delete + create).
+  static Future<void> replaceRecords({
+    required String userId,
+    required TransactionExecutor txn,
+    List<dynamic>? workExperiences,
+    List<dynamic>? education,
+    List<dynamic>? certifications,
+  }) async {
+    await deleteRecords(userId: userId, txn: txn);
+    await createRecords(
+      userId: userId,
+      txn: txn,
+      workExperiences: workExperiences,
+      education: education,
+      certifications: certifications,
+    );
+  }
+}

--- a/backend/routes/api/onboarding/submit.dart
+++ b/backend/routes/api/onboarding/submit.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/professional_background_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
@@ -282,103 +283,18 @@ Future<String> _processConsultantOnboarding(
     );
 
     // Create professional background records if provided
-    final workExperiences =
-        consultantProfile['workExperiences'] as List<dynamic>?;
-    final education = consultantProfile['education'] as List<dynamic>?;
-    final certifications =
-        consultantProfile['certifications'] as List<dynamic>?;
-
-    await _createProfessionalBackground(
-      db: db,
+    await ProfessionalBackgroundUtils.createRecords(
       userId: userId,
-      workExperiences: workExperiences,
-      education: education,
-      certifications: certifications,
       txn: txn,
+      workExperiences:
+          consultantProfile['workExperiences'] as List<dynamic>?,
+      education: consultantProfile['education'] as List<dynamic>?,
+      certifications:
+          consultantProfile['certifications'] as List<dynamic>?,
     );
 
     return profileId;
   });
-}
-
-/// Create professional background records within a transaction.
-Future<void> _createProfessionalBackground({
-  required DatabaseClient db,
-  required String userId,
-  List<dynamic>? workExperiences,
-  List<dynamic>? education,
-  List<dynamic>? certifications,
-  required TransactionExecutor txn,
-}) async {
-  final now = DateTime.now().toUtc().toIso8601String();
-
-  if (workExperiences != null) {
-    for (final we in workExperiences) {
-      final item = we as Map<String, dynamic>;
-      final query = JsonQueryBuilder()
-          .model('WorkExperience')
-          .action(QueryAction.create)
-          .data({
-        'userId': userId,
-        'company': item['company'],
-        'companyDomain': item['companyDomain'],
-        'title': item['title'],
-        'location': item['location'],
-        'startDate': item['startDate'],
-        'endDate': item['endDate'],
-        'isCurrent': item['isCurrent'] ?? false,
-        'description': item['description'],
-        'createdAt': now,
-        'updatedAt': now,
-      }).build();
-      await txn.executeMutation(query);
-    }
-  }
-
-  if (education != null) {
-    for (final edu in education) {
-      final item = edu as Map<String, dynamic>;
-      final query = JsonQueryBuilder()
-          .model('Education')
-          .action(QueryAction.create)
-          .data({
-        'userId': userId,
-        'institution': item['institution'],
-        'institutionDomain': item['institutionDomain'],
-        'degree': item['degree'],
-        'fieldOfStudy': item['fieldOfStudy'],
-        'startYear': item['startYear'],
-        'endYear': item['endYear'],
-        'grade': item['grade'],
-        'activities': item['activities'],
-        'description': item['description'],
-        'createdAt': now,
-        'updatedAt': now,
-      }).build();
-      await txn.executeMutation(query);
-    }
-  }
-
-  if (certifications != null) {
-    for (final cert in certifications) {
-      final item = cert as Map<String, dynamic>;
-      final query = JsonQueryBuilder()
-          .model('Certification')
-          .action(QueryAction.create)
-          .data({
-        'userId': userId,
-        'name': item['name'],
-        'issuingOrganization': item['issuingOrganization'],
-        'issueDate': item['issueDate'],
-        'expiryDate': item['expiryDate'],
-        'credentialId': item['credentialId'],
-        'credentialUrl': item['credentialUrl'],
-        'createdAt': now,
-        'updatedAt': now,
-      }).build();
-      await txn.executeMutation(query);
-    }
-  }
 }
 
 /// Parse a value as List<String>

--- a/backend/routes/api/onboarding/submit.dart
+++ b/backend/routes/api/onboarding/submit.dart
@@ -5,6 +5,7 @@ import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// POST /api/onboarding/submit
 ///
@@ -280,8 +281,104 @@ Future<String> _processConsultantOnboarding(
       txn: txn,
     );
 
+    // Create professional background records if provided
+    final workExperiences =
+        consultantProfile['workExperiences'] as List<dynamic>?;
+    final education = consultantProfile['education'] as List<dynamic>?;
+    final certifications =
+        consultantProfile['certifications'] as List<dynamic>?;
+
+    await _createProfessionalBackground(
+      db: db,
+      userId: userId,
+      workExperiences: workExperiences,
+      education: education,
+      certifications: certifications,
+      txn: txn,
+    );
+
     return profileId;
   });
+}
+
+/// Create professional background records within a transaction.
+Future<void> _createProfessionalBackground({
+  required DatabaseClient db,
+  required String userId,
+  List<dynamic>? workExperiences,
+  List<dynamic>? education,
+  List<dynamic>? certifications,
+  required TransactionExecutor txn,
+}) async {
+  final now = DateTime.now().toUtc().toIso8601String();
+
+  if (workExperiences != null) {
+    for (final we in workExperiences) {
+      final item = we as Map<String, dynamic>;
+      final query = JsonQueryBuilder()
+          .model('WorkExperience')
+          .action(QueryAction.create)
+          .data({
+        'userId': userId,
+        'company': item['company'],
+        'companyDomain': item['companyDomain'],
+        'title': item['title'],
+        'location': item['location'],
+        'startDate': item['startDate'],
+        'endDate': item['endDate'],
+        'isCurrent': item['isCurrent'] ?? false,
+        'description': item['description'],
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+      await txn.executeMutation(query);
+    }
+  }
+
+  if (education != null) {
+    for (final edu in education) {
+      final item = edu as Map<String, dynamic>;
+      final query = JsonQueryBuilder()
+          .model('Education')
+          .action(QueryAction.create)
+          .data({
+        'userId': userId,
+        'institution': item['institution'],
+        'institutionDomain': item['institutionDomain'],
+        'degree': item['degree'],
+        'fieldOfStudy': item['fieldOfStudy'],
+        'startYear': item['startYear'],
+        'endYear': item['endYear'],
+        'grade': item['grade'],
+        'activities': item['activities'],
+        'description': item['description'],
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+      await txn.executeMutation(query);
+    }
+  }
+
+  if (certifications != null) {
+    for (final cert in certifications) {
+      final item = cert as Map<String, dynamic>;
+      final query = JsonQueryBuilder()
+          .model('Certification')
+          .action(QueryAction.create)
+          .data({
+        'userId': userId,
+        'name': item['name'],
+        'issuingOrganization': item['issuingOrganization'],
+        'issueDate': item['issueDate'],
+        'expiryDate': item['expiryDate'],
+        'credentialId': item['credentialId'],
+        'credentialUrl': item['credentialUrl'],
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+      await txn.executeMutation(query);
+    }
+  }
 }
 
 /// Parse a value as List<String>

--- a/backend/routes/api/user/[id]/professional-background/index.dart
+++ b/backend/routes/api/user/[id]/professional-background/index.dart
@@ -1,0 +1,209 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/user/:id/professional-background
+///   Returns work experiences, education, and certifications.
+///
+/// PUT /api/user/:id/professional-background
+///   Replaces all professional background records for the user.
+///   Body: { workExperiences: [...], education: [...], certifications: [...] }
+Future<Response> onRequest(RequestContext context, String id) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) {
+    return _handleGet(context, id);
+  } else if (method == HttpMethod.put) {
+    return _handlePut(context, id);
+  }
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null || userId != id) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    final weQuery = JsonQueryBuilder()
+        .model('WorkExperience')
+        .action(QueryAction.findMany)
+        .where({'userId': userId})
+        .build();
+    final workExperiences = await db.executor.executeQueryAsMaps(weQuery);
+
+    final eduQuery = JsonQueryBuilder()
+        .model('Education')
+        .action(QueryAction.findMany)
+        .where({'userId': userId})
+        .build();
+    final education = await db.executor.executeQueryAsMaps(eduQuery);
+
+    final certQuery = JsonQueryBuilder()
+        .model('Certification')
+        .action(QueryAction.findMany)
+        .where({'userId': userId})
+        .build();
+    final certifications = await db.executor.executeQueryAsMaps(certQuery);
+
+    return Response.json(
+      body: {
+        'data': {
+          'workExperiences':
+              workExperiences.map(serializeForJson).toList(),
+          'education': education.map(serializeForJson).toList(),
+          'certifications':
+              certifications.map(serializeForJson).toList(),
+        },
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Failed to get professional background',
+      context: 'ProfessionalBackgroundGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to get professional background'},
+      },
+    );
+  }
+}
+
+Future<Response> _handlePut(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null || userId != id) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {
+          'error': {'message': 'Unauthorized'},
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final db = context.read<DatabaseClient>();
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    await db.executeInTransaction((txn) async {
+      // Delete existing records
+      for (final model in [
+        'WorkExperience',
+        'Education',
+        'Certification',
+      ]) {
+        final deleteQuery = JsonQueryBuilder()
+            .model(model)
+            .action(QueryAction.deleteMany)
+            .where({'userId': userId})
+            .build();
+        await txn.executeMutation(deleteQuery);
+      }
+
+      // Re-create work experiences
+      final workExperiences =
+          body['workExperiences'] as List<dynamic>? ?? [];
+      for (final we in workExperiences) {
+        final item = we as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('WorkExperience')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'company': item['company'],
+          'companyDomain': item['companyDomain'],
+          'title': item['title'],
+          'location': item['location'],
+          'startDate': item['startDate'],
+          'endDate': item['endDate'],
+          'isCurrent': item['isCurrent'] ?? false,
+          'description': item['description'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+
+      // Re-create education
+      final education = body['education'] as List<dynamic>? ?? [];
+      for (final edu in education) {
+        final item = edu as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('Education')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'institution': item['institution'],
+          'institutionDomain': item['institutionDomain'],
+          'degree': item['degree'],
+          'fieldOfStudy': item['fieldOfStudy'],
+          'startYear': item['startYear'],
+          'endYear': item['endYear'],
+          'grade': item['grade'],
+          'activities': item['activities'],
+          'description': item['description'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+
+      // Re-create certifications
+      final certifications =
+          body['certifications'] as List<dynamic>? ?? [];
+      for (final cert in certifications) {
+        final item = cert as Map<String, dynamic>;
+        final query = JsonQueryBuilder()
+            .model('Certification')
+            .action(QueryAction.create)
+            .data({
+          'userId': userId,
+          'name': item['name'],
+          'issuingOrganization': item['issuingOrganization'],
+          'issueDate': item['issueDate'],
+          'expiryDate': item['expiryDate'],
+          'credentialId': item['credentialId'],
+          'credentialUrl': item['credentialUrl'],
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
+        await txn.executeMutation(query);
+      }
+    });
+
+    return Response.json(
+      body: {'message': 'Professional background updated'},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Failed to update professional background',
+      context: 'ProfessionalBackgroundPut',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to update professional background'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/user/[id]/professional-background/index.dart
+++ b/backend/routes/api/user/[id]/professional-background/index.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/professional_background_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
 import 'package:prisma_flutter_connector/runtime_server.dart';
@@ -101,92 +102,15 @@ Future<Response> _handlePut(RequestContext context, String id) async {
 
     final body = await context.request.json() as Map<String, dynamic>;
     final db = context.read<DatabaseClient>();
-    final now = DateTime.now().toUtc().toIso8601String();
 
     await db.executeInTransaction((txn) async {
-      // Delete existing records
-      for (final model in [
-        'WorkExperience',
-        'Education',
-        'Certification',
-      ]) {
-        final deleteQuery = JsonQueryBuilder()
-            .model(model)
-            .action(QueryAction.deleteMany)
-            .where({'userId': userId})
-            .build();
-        await txn.executeMutation(deleteQuery);
-      }
-
-      // Re-create work experiences
-      final workExperiences =
-          body['workExperiences'] as List<dynamic>? ?? [];
-      for (final we in workExperiences) {
-        final item = we as Map<String, dynamic>;
-        final query = JsonQueryBuilder()
-            .model('WorkExperience')
-            .action(QueryAction.create)
-            .data({
-          'userId': userId,
-          'company': item['company'],
-          'companyDomain': item['companyDomain'],
-          'title': item['title'],
-          'location': item['location'],
-          'startDate': item['startDate'],
-          'endDate': item['endDate'],
-          'isCurrent': item['isCurrent'] ?? false,
-          'description': item['description'],
-          'createdAt': now,
-          'updatedAt': now,
-        }).build();
-        await txn.executeMutation(query);
-      }
-
-      // Re-create education
-      final education = body['education'] as List<dynamic>? ?? [];
-      for (final edu in education) {
-        final item = edu as Map<String, dynamic>;
-        final query = JsonQueryBuilder()
-            .model('Education')
-            .action(QueryAction.create)
-            .data({
-          'userId': userId,
-          'institution': item['institution'],
-          'institutionDomain': item['institutionDomain'],
-          'degree': item['degree'],
-          'fieldOfStudy': item['fieldOfStudy'],
-          'startYear': item['startYear'],
-          'endYear': item['endYear'],
-          'grade': item['grade'],
-          'activities': item['activities'],
-          'description': item['description'],
-          'createdAt': now,
-          'updatedAt': now,
-        }).build();
-        await txn.executeMutation(query);
-      }
-
-      // Re-create certifications
-      final certifications =
-          body['certifications'] as List<dynamic>? ?? [];
-      for (final cert in certifications) {
-        final item = cert as Map<String, dynamic>;
-        final query = JsonQueryBuilder()
-            .model('Certification')
-            .action(QueryAction.create)
-            .data({
-          'userId': userId,
-          'name': item['name'],
-          'issuingOrganization': item['issuingOrganization'],
-          'issueDate': item['issueDate'],
-          'expiryDate': item['expiryDate'],
-          'credentialId': item['credentialId'],
-          'credentialUrl': item['credentialUrl'],
-          'createdAt': now,
-          'updatedAt': now,
-        }).build();
-        await txn.executeMutation(query);
-      }
+      await ProfessionalBackgroundUtils.replaceRecords(
+        userId: userId,
+        txn: txn,
+        workExperiences: body['workExperiences'] as List<dynamic>?,
+        education: body['education'] as List<dynamic>?,
+        certifications: body['certifications'] as List<dynamic>?,
+      );
     });
 
     return Response.json(

--- a/lib/data/models/onboarding/onboarding_request_model.dart
+++ b/lib/data/models/onboarding/onboarding_request_model.dart
@@ -88,6 +88,47 @@ class OnboardingRequestModel with _$OnboardingRequestModel {
               twitterUrl: state.consultantProfile!.twitterUrl,
               githubUrl: state.consultantProfile!.githubUrl,
               videoIntroUrl: state.consultantProfile!.videoIntroUrl,
+              workExperiences: state.consultantProfile!.workExperiences
+                  .map(
+                    (we) => WorkExperienceRequest(
+                      company: we.company,
+                      companyDomain: we.companyDomain,
+                      title: we.title,
+                      location: we.location,
+                      startDate: we.startDate.toIso8601String(),
+                      endDate: we.endDate?.toIso8601String(),
+                      isCurrent: we.isCurrent,
+                      description: we.description,
+                    ),
+                  )
+                  .toList(),
+              education: state.consultantProfile!.education
+                  .map(
+                    (edu) => EducationRequest(
+                      institution: edu.institution,
+                      institutionDomain: edu.institutionDomain,
+                      degree: edu.degree,
+                      fieldOfStudy: edu.fieldOfStudy,
+                      startYear: edu.startYear,
+                      endYear: edu.endYear,
+                      grade: edu.grade,
+                      activities: edu.activities,
+                      description: edu.description,
+                    ),
+                  )
+                  .toList(),
+              certifications: state.consultantProfile!.certifications
+                  .map(
+                    (cert) => CertificationRequest(
+                      name: cert.name,
+                      issuingOrganization: cert.issuingOrganization,
+                      issueDate: cert.issueDate.toIso8601String(),
+                      expiryDate: cert.expiryDate?.toIso8601String(),
+                      credentialId: cert.credentialId,
+                      credentialUrl: cert.credentialUrl,
+                    ),
+                  )
+                  .toList(),
             )
           : null,
       agreement: AgreementRequest(
@@ -155,10 +196,63 @@ class ConsultantProfileRequest with _$ConsultantProfileRequest {
     String? twitterUrl,
     String? githubUrl,
     String? videoIntroUrl,
+    @Default([]) List<WorkExperienceRequest> workExperiences,
+    @Default([]) List<EducationRequest> education,
+    @Default([]) List<CertificationRequest> certifications,
   }) = _ConsultantProfileRequest;
 
   factory ConsultantProfileRequest.fromJson(Map<String, dynamic> json) =>
       _$ConsultantProfileRequestFromJson(json);
+}
+
+@freezed
+class WorkExperienceRequest with _$WorkExperienceRequest {
+  const factory WorkExperienceRequest({
+    required String company,
+    String? companyDomain,
+    required String title,
+    String? location,
+    required String startDate,
+    String? endDate,
+    @Default(false) bool isCurrent,
+    String? description,
+  }) = _WorkExperienceRequest;
+
+  factory WorkExperienceRequest.fromJson(Map<String, dynamic> json) =>
+      _$WorkExperienceRequestFromJson(json);
+}
+
+@freezed
+class EducationRequest with _$EducationRequest {
+  const factory EducationRequest({
+    required String institution,
+    String? institutionDomain,
+    required String degree,
+    String? fieldOfStudy,
+    int? startYear,
+    int? endYear,
+    String? grade,
+    String? activities,
+    String? description,
+  }) = _EducationRequest;
+
+  factory EducationRequest.fromJson(Map<String, dynamic> json) =>
+      _$EducationRequestFromJson(json);
+}
+
+@freezed
+class CertificationRequest with _$CertificationRequest {
+  const factory CertificationRequest({
+    required String name,
+    required String issuingOrganization,
+    required String issueDate,
+    String? expiryDate,
+    String? credentialId,
+    String? credentialUrl,
+  }) = _CertificationRequest;
+
+  factory CertificationRequest.fromJson(Map<String, dynamic> json) =>
+      _$CertificationRequestFromJson(json);
 }
 
 @freezed

--- a/lib/domain/entities/onboarding/consultant_profile_data.dart
+++ b/lib/domain/entities/onboarding/consultant_profile_data.dart
@@ -48,6 +48,15 @@ class ConsultantProfileData with _$ConsultantProfileData {
 
     /// Video introduction URL
     String? videoIntroUrl,
+
+    /// Professional background — work experiences
+    @Default([]) List<WorkExperienceEntry> workExperiences,
+
+    /// Professional background — education
+    @Default([]) List<EducationEntry> education,
+
+    /// Professional background — certifications
+    @Default([]) List<CertificationEntry> certifications,
   }) = _ConsultantProfileData;
 
   const ConsultantProfileData._();
@@ -58,4 +67,54 @@ class ConsultantProfileData with _$ConsultantProfileData {
   /// Check if profile data is valid
   /// Domain is required for consultants
   bool get isValid => domainId != null && domainId!.isNotEmpty;
+}
+
+@freezed
+class WorkExperienceEntry with _$WorkExperienceEntry {
+  const factory WorkExperienceEntry({
+    required String company,
+    String? companyDomain,
+    required String title,
+    String? location,
+    required DateTime startDate,
+    DateTime? endDate,
+    @Default(false) bool isCurrent,
+    String? description,
+  }) = _WorkExperienceEntry;
+
+  factory WorkExperienceEntry.fromJson(Map<String, dynamic> json) =>
+      _$WorkExperienceEntryFromJson(json);
+}
+
+@freezed
+class EducationEntry with _$EducationEntry {
+  const factory EducationEntry({
+    required String institution,
+    String? institutionDomain,
+    required String degree,
+    String? fieldOfStudy,
+    int? startYear,
+    int? endYear,
+    String? grade,
+    String? activities,
+    String? description,
+  }) = _EducationEntry;
+
+  factory EducationEntry.fromJson(Map<String, dynamic> json) =>
+      _$EducationEntryFromJson(json);
+}
+
+@freezed
+class CertificationEntry with _$CertificationEntry {
+  const factory CertificationEntry({
+    required String name,
+    required String issuingOrganization,
+    required DateTime issueDate,
+    DateTime? expiryDate,
+    String? credentialId,
+    String? credentialUrl,
+  }) = _CertificationEntry;
+
+  factory CertificationEntry.fromJson(Map<String, dynamic> json) =>
+      _$CertificationEntryFromJson(json);
 }

--- a/lib/domain/entities/onboarding/onboarding_state.dart
+++ b/lib/domain/entities/onboarding/onboarding_state.dart
@@ -56,42 +56,51 @@ class OnboardingState with _$OnboardingState {
   factory OnboardingState.fromJson(Map<String, dynamic> json) =>
       _$OnboardingStateFromJson(json);
 
-  /// Total number of steps (same for both roles)
-  /// Steps: 0=Role, 1=Personal Info, 2=Profile, 3=Preferences/Availability, 4=Agreement, 5=Review
-  int get totalSteps => 6;
+  /// Total number of steps (varies by role).
+  /// Consultee: 0=Role, 1=Personal, 2=Profile, 3=Preferences, 4=Agreement, 5=Review (6 steps)
+  /// Consultant: 0=Role, 1=Personal, 2=Profile, 3=Background, 4=Availability, 5=Agreement, 6=Review (7 steps)
+  int get totalSteps =>
+      selectedRole == UserRole.consultant ? 7 : 6;
 
   /// Progress as a fraction (0.0 to 1.0)
   double get progress => (currentStep + 1) / totalSteps;
 
-  /// Check if current step is valid and user can proceed
+  /// Check if current step is valid and user can proceed.
+  ///
+  /// Step indices differ by role:
+  /// Consultee: 0=Role, 1=Personal, 2=Profile, 3=Preferences, 4=Agreement, 5=Review
+  /// Consultant: 0=Role, 1=Personal, 2=Profile, 3=Background, 4=Availability, 5=Agreement, 6=Review
   bool get canProceed {
+    final isConsultant = selectedRole == UserRole.consultant;
+
     switch (currentStep) {
       case 0:
-        // Role selection step: always valid (default role is set)
-        return true;
+        return true; // Role selection
       case 1:
-        // Personal info step: name is required
-        return personalInfo?.isValid ?? false;
+        return personalInfo?.isValid ?? false; // Personal info
       case 2:
-        // Profile step: depends on role
-        if (selectedRole == UserRole.consultee) {
-          return consulteeProfile?.isValid ?? true; // All optional
-        } else {
-          return consultantProfile?.isValid ?? false; // Domain required
+        // Profile step
+        if (isConsultant) {
+          return consultantProfile?.isValid ?? false;
         }
+        return consulteeProfile?.isValid ?? true;
       case 3:
-        // Preferences (consultee) or Availability info (consultant)
-        if (selectedRole == UserRole.consultee) {
-          return preferences?.isValid ?? true;
-        } else {
-          return true; // Info screen, always valid
+        if (isConsultant) {
+          return true; // Professional background (all optional)
         }
+        return preferences?.isValid ?? true; // Consultee preferences
       case 4:
-        // Agreement step
-        return agreement?.isAccepted ?? false;
+        if (isConsultant) {
+          return true; // Availability info
+        }
+        return agreement?.isAccepted ?? false; // Consultee agreement
       case 5:
-        // Review step - can always proceed (submit)
-        return true;
+        if (isConsultant) {
+          return agreement?.isAccepted ?? false; // Consultant agreement
+        }
+        return true; // Consultee review
+      case 6:
+        return true; // Consultant review
       default:
         return false;
     }

--- a/lib/features/onboarding/screens/onboarding_shell_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_shell_screen.dart
@@ -123,6 +123,7 @@ class OnboardingShellScreen extends ConsumerWidget {
         'Role',
         'Personal Info',
         'Professional',
+        'Background',
         'Availability',
         'Agreement',
         'Review',
@@ -131,29 +132,29 @@ class OnboardingShellScreen extends ConsumerWidget {
   }
 
   Widget _buildStepContent(int step, UserRole role) {
-    switch (step) {
-      case 0:
-        return const RoleSelectionStep();
-      case 1:
-        return const PersonalInfoStep();
-      case 2:
-        if (role == UserRole.consultee) {
-          return const ConsulteeProfileStep();
-        } else {
-          return const ConsultantProfileStep();
-        }
-      case 3:
-        if (role == UserRole.consultee) {
-          return const PreferencesStep();
-        } else {
-          return const AvailabilityInfoStep();
-        }
-      case 4:
-        return const AgreementStep();
-      case 5:
-        return const ReviewStep();
-      default:
-        return const SizedBox.shrink();
+    // Consultee: 0=Role, 1=Personal, 2=Profile, 3=Preferences, 4=Agreement, 5=Review
+    // Consultant: 0=Role, 1=Personal, 2=Profile, 3=Background, 4=Availability, 5=Agreement, 6=Review
+    if (role == UserRole.consultee) {
+      return switch (step) {
+        0 => const RoleSelectionStep(),
+        1 => const PersonalInfoStep(),
+        2 => const ConsulteeProfileStep(),
+        3 => const PreferencesStep(),
+        4 => const AgreementStep(),
+        5 => const ReviewStep(),
+        _ => const SizedBox.shrink(),
+      };
+    } else {
+      return switch (step) {
+        0 => const RoleSelectionStep(),
+        1 => const PersonalInfoStep(),
+        2 => const ConsultantProfileStep(),
+        3 => const ProfessionalBackgroundStep(),
+        4 => const AvailabilityInfoStep(),
+        5 => const AgreementStep(),
+        6 => const ReviewStep(),
+        _ => const SizedBox.shrink(),
+      };
     }
   }
 

--- a/lib/features/onboarding/screens/steps/professional_background_step.dart
+++ b/lib/features/onboarding/screens/steps/professional_background_step.dart
@@ -1,0 +1,624 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../domain/entities/onboarding/consultant_profile_data.dart';
+import '../../providers/onboarding_provider.dart';
+
+/// Onboarding step for consultant professional background.
+///
+/// Collects work experience, education, and certifications.
+/// Displayed after the consultant profile step, before availability.
+class ProfessionalBackgroundStep extends ConsumerStatefulWidget {
+  const ProfessionalBackgroundStep({super.key});
+
+  @override
+  ConsumerState<ProfessionalBackgroundStep> createState() =>
+      _ProfessionalBackgroundStepState();
+}
+
+class _ProfessionalBackgroundStepState
+    extends ConsumerState<ProfessionalBackgroundStep> {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(onboardingProvider);
+    final profile = state.consultantProfile;
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Professional Background',
+            style: theme.textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Add your experience, education, and certifications '
+            'to build credibility.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: Colors.grey[600],
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Work Experience Section
+          _SectionHeader(
+            title: 'Work Experience',
+            icon: Icons.work,
+            count: profile?.workExperiences.length ?? 0,
+            onAdd: () => _addWorkExperience(context),
+          ),
+          if (profile != null && profile.workExperiences.isNotEmpty)
+            ...profile.workExperiences.asMap().entries.map(
+                  (entry) => _WorkExperienceCard(
+                    experience: entry.value,
+                    onRemove: () => _removeWorkExperience(entry.key),
+                  ),
+                ),
+          const SizedBox(height: 24),
+
+          // Education Section
+          _SectionHeader(
+            title: 'Education',
+            icon: Icons.school,
+            count: profile?.education.length ?? 0,
+            onAdd: () => _addEducation(context),
+          ),
+          if (profile != null && profile.education.isNotEmpty)
+            ...profile.education.asMap().entries.map(
+                  (entry) => _EducationCard(
+                    education: entry.value,
+                    onRemove: () => _removeEducation(entry.key),
+                  ),
+                ),
+          const SizedBox(height: 24),
+
+          // Certifications Section
+          _SectionHeader(
+            title: 'Certifications',
+            icon: Icons.verified,
+            count: profile?.certifications.length ?? 0,
+            onAdd: () => _addCertification(context),
+          ),
+          if (profile != null && profile.certifications.isNotEmpty)
+            ...profile.certifications.asMap().entries.map(
+                  (entry) => _CertificationCard(
+                    certification: entry.value,
+                    onRemove: () => _removeCertification(entry.key),
+                  ),
+                ),
+          const SizedBox(height: 16),
+          Text(
+            'All fields are optional. You can add more later from '
+            'your profile settings.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: Colors.grey,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _addWorkExperience(BuildContext context) async {
+    final result = await showDialog<WorkExperienceEntry>(
+      context: context,
+      builder: (_) => const _WorkExperienceDialog(),
+    );
+    if (result != null) {
+      final notifier = ref.read(onboardingProvider.notifier);
+      final profile = ref.read(onboardingProvider).consultantProfile;
+      if (profile != null) {
+        notifier.updateConsultantProfile(
+          profile.copyWith(
+            workExperiences: [...profile.workExperiences, result],
+          ),
+        );
+      }
+    }
+  }
+
+  void _removeWorkExperience(int index) {
+    final notifier = ref.read(onboardingProvider.notifier);
+    final profile = ref.read(onboardingProvider).consultantProfile;
+    if (profile != null) {
+      final list = [...profile.workExperiences]..removeAt(index);
+      notifier.updateConsultantProfile(
+        profile.copyWith(workExperiences: list),
+      );
+    }
+  }
+
+  void _addEducation(BuildContext context) async {
+    final result = await showDialog<EducationEntry>(
+      context: context,
+      builder: (_) => const _EducationDialog(),
+    );
+    if (result != null) {
+      final notifier = ref.read(onboardingProvider.notifier);
+      final profile = ref.read(onboardingProvider).consultantProfile;
+      if (profile != null) {
+        notifier.updateConsultantProfile(
+          profile.copyWith(education: [...profile.education, result]),
+        );
+      }
+    }
+  }
+
+  void _removeEducation(int index) {
+    final notifier = ref.read(onboardingProvider.notifier);
+    final profile = ref.read(onboardingProvider).consultantProfile;
+    if (profile != null) {
+      final list = [...profile.education]..removeAt(index);
+      notifier.updateConsultantProfile(
+        profile.copyWith(education: list),
+      );
+    }
+  }
+
+  void _addCertification(BuildContext context) async {
+    final result = await showDialog<CertificationEntry>(
+      context: context,
+      builder: (_) => const _CertificationDialog(),
+    );
+    if (result != null) {
+      final notifier = ref.read(onboardingProvider.notifier);
+      final profile = ref.read(onboardingProvider).consultantProfile;
+      if (profile != null) {
+        notifier.updateConsultantProfile(
+          profile.copyWith(
+            certifications: [...profile.certifications, result],
+          ),
+        );
+      }
+    }
+  }
+
+  void _removeCertification(int index) {
+    final notifier = ref.read(onboardingProvider.notifier);
+    final profile = ref.read(onboardingProvider).consultantProfile;
+    if (profile != null) {
+      final list = [...profile.certifications]..removeAt(index);
+      notifier.updateConsultantProfile(
+        profile.copyWith(certifications: list),
+      );
+    }
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({
+    required this.title,
+    required this.icon,
+    required this.count,
+    required this.onAdd,
+  });
+
+  final String title;
+  final IconData icon;
+  final int count;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 20),
+        const SizedBox(width: 8),
+        Text(
+          '$title ($count)',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const Spacer(),
+        TextButton.icon(
+          onPressed: onAdd,
+          icon: const Icon(Icons.add, size: 18),
+          label: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkExperienceCard extends StatelessWidget {
+  const _WorkExperienceCard({
+    required this.experience,
+    required this.onRemove,
+  });
+
+  final WorkExperienceEntry experience;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text(experience.title),
+        subtitle: Text(
+          '${experience.company}'
+          '${experience.isCurrent ? " (Current)" : ""}',
+        ),
+        trailing: IconButton(
+          icon: const Icon(Icons.close, size: 18),
+          onPressed: onRemove,
+        ),
+      ),
+    );
+  }
+}
+
+class _EducationCard extends StatelessWidget {
+  const _EducationCard({
+    required this.education,
+    required this.onRemove,
+  });
+
+  final EducationEntry education;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text(education.degree),
+        subtitle: Text(education.institution),
+        trailing: IconButton(
+          icon: const Icon(Icons.close, size: 18),
+          onPressed: onRemove,
+        ),
+      ),
+    );
+  }
+}
+
+class _CertificationCard extends StatelessWidget {
+  const _CertificationCard({
+    required this.certification,
+    required this.onRemove,
+  });
+
+  final CertificationEntry certification;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text(certification.name),
+        subtitle: Text(certification.issuingOrganization),
+        trailing: IconButton(
+          icon: const Icon(Icons.close, size: 18),
+          onPressed: onRemove,
+        ),
+      ),
+    );
+  }
+}
+
+// -- Dialogs for adding entries --
+
+class _WorkExperienceDialog extends StatefulWidget {
+  const _WorkExperienceDialog();
+
+  @override
+  State<_WorkExperienceDialog> createState() => _WorkExperienceDialogState();
+}
+
+class _WorkExperienceDialogState extends State<_WorkExperienceDialog> {
+  final _companyCtrl = TextEditingController();
+  final _titleCtrl = TextEditingController();
+  final _locationCtrl = TextEditingController();
+  final _descCtrl = TextEditingController();
+  DateTime _startDate = DateTime.now();
+  DateTime? _endDate;
+  bool _isCurrent = false;
+
+  @override
+  void dispose() {
+    _companyCtrl.dispose();
+    _titleCtrl.dispose();
+    _locationCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add Work Experience'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _companyCtrl,
+              decoration: const InputDecoration(labelText: 'Company *'),
+            ),
+            TextField(
+              controller: _titleCtrl,
+              decoration: const InputDecoration(labelText: 'Job Title *'),
+            ),
+            TextField(
+              controller: _locationCtrl,
+              decoration: const InputDecoration(labelText: 'Location'),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                'Start: ${DateFormat.yMMMM().format(_startDate)}',
+              ),
+              trailing: const Icon(Icons.calendar_today, size: 18),
+              onTap: () async {
+                final date = await showDatePicker(
+                  context: context,
+                  initialDate: _startDate,
+                  firstDate: DateTime(1970),
+                  lastDate: DateTime.now(),
+                );
+                if (date != null) setState(() => _startDate = date);
+              },
+            ),
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Currently working here'),
+              value: _isCurrent,
+              onChanged: (v) => setState(() {
+                _isCurrent = v ?? false;
+                if (_isCurrent) _endDate = null;
+              }),
+            ),
+            if (!_isCurrent)
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(
+                  _endDate != null
+                      ? 'End: ${DateFormat.yMMMM().format(_endDate!)}'
+                      : 'End date (tap to set)',
+                ),
+                trailing: const Icon(Icons.calendar_today, size: 18),
+                onTap: () async {
+                  final date = await showDatePicker(
+                    context: context,
+                    initialDate: _endDate ?? DateTime.now(),
+                    firstDate: _startDate,
+                    lastDate: DateTime.now(),
+                  );
+                  if (date != null) setState(() => _endDate = date);
+                },
+              ),
+            TextField(
+              controller: _descCtrl,
+              decoration: const InputDecoration(labelText: 'Description'),
+              maxLines: 2,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (_companyCtrl.text.isEmpty || _titleCtrl.text.isEmpty) return;
+            Navigator.pop(
+              context,
+              WorkExperienceEntry(
+                company: _companyCtrl.text,
+                title: _titleCtrl.text,
+                location: _locationCtrl.text.isNotEmpty
+                    ? _locationCtrl.text
+                    : null,
+                startDate: _startDate,
+                endDate: _endDate,
+                isCurrent: _isCurrent,
+                description:
+                    _descCtrl.text.isNotEmpty ? _descCtrl.text : null,
+              ),
+            );
+          },
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}
+
+class _EducationDialog extends StatefulWidget {
+  const _EducationDialog();
+
+  @override
+  State<_EducationDialog> createState() => _EducationDialogState();
+}
+
+class _EducationDialogState extends State<_EducationDialog> {
+  final _institutionCtrl = TextEditingController();
+  final _degreeCtrl = TextEditingController();
+  final _fieldCtrl = TextEditingController();
+  final _startYearCtrl = TextEditingController();
+  final _endYearCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _institutionCtrl.dispose();
+    _degreeCtrl.dispose();
+    _fieldCtrl.dispose();
+    _startYearCtrl.dispose();
+    _endYearCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add Education'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _institutionCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'Institution *'),
+            ),
+            TextField(
+              controller: _degreeCtrl,
+              decoration: const InputDecoration(labelText: 'Degree *'),
+            ),
+            TextField(
+              controller: _fieldCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'Field of Study'),
+            ),
+            TextField(
+              controller: _startYearCtrl,
+              decoration: const InputDecoration(labelText: 'Start Year'),
+              keyboardType: TextInputType.number,
+            ),
+            TextField(
+              controller: _endYearCtrl,
+              decoration: const InputDecoration(labelText: 'End Year'),
+              keyboardType: TextInputType.number,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (_institutionCtrl.text.isEmpty ||
+                _degreeCtrl.text.isEmpty) {
+              return;
+            }
+            Navigator.pop(
+              context,
+              EducationEntry(
+                institution: _institutionCtrl.text,
+                degree: _degreeCtrl.text,
+                fieldOfStudy: _fieldCtrl.text.isNotEmpty
+                    ? _fieldCtrl.text
+                    : null,
+                startYear: int.tryParse(_startYearCtrl.text),
+                endYear: int.tryParse(_endYearCtrl.text),
+              ),
+            );
+          },
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}
+
+class _CertificationDialog extends StatefulWidget {
+  const _CertificationDialog();
+
+  @override
+  State<_CertificationDialog> createState() => _CertificationDialogState();
+}
+
+class _CertificationDialogState extends State<_CertificationDialog> {
+  final _nameCtrl = TextEditingController();
+  final _orgCtrl = TextEditingController();
+  final _credIdCtrl = TextEditingController();
+  final _credUrlCtrl = TextEditingController();
+  DateTime _issueDate = DateTime.now();
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _orgCtrl.dispose();
+    _credIdCtrl.dispose();
+    _credUrlCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add Certification'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _nameCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'Certification Name *'),
+            ),
+            TextField(
+              controller: _orgCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Issuing Organization *',
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                'Issued: ${DateFormat.yMMMM().format(_issueDate)}',
+              ),
+              trailing: const Icon(Icons.calendar_today, size: 18),
+              onTap: () async {
+                final date = await showDatePicker(
+                  context: context,
+                  initialDate: _issueDate,
+                  firstDate: DateTime(1970),
+                  lastDate: DateTime.now(),
+                );
+                if (date != null) setState(() => _issueDate = date);
+              },
+            ),
+            TextField(
+              controller: _credIdCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'Credential ID'),
+            ),
+            TextField(
+              controller: _credUrlCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'Credential URL'),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (_nameCtrl.text.isEmpty || _orgCtrl.text.isEmpty) return;
+            Navigator.pop(
+              context,
+              CertificationEntry(
+                name: _nameCtrl.text,
+                issuingOrganization: _orgCtrl.text,
+                issueDate: _issueDate,
+                credentialId: _credIdCtrl.text.isNotEmpty
+                    ? _credIdCtrl.text
+                    : null,
+                credentialUrl: _credUrlCtrl.text.isNotEmpty
+                    ? _credUrlCtrl.text
+                    : null,
+              ),
+            );
+          },
+          child: const Text('Add'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/onboarding/screens/steps/steps.dart
+++ b/lib/features/onboarding/screens/steps/steps.dart
@@ -7,5 +7,6 @@ export 'consultee_profile_step.dart';
 export 'consultant_profile_step.dart';
 export 'personal_info_step.dart';
 export 'preferences_step.dart';
+export 'professional_background_step.dart';
 export 'review_step.dart';
 export 'role_selection_step.dart';


### PR DESCRIPTION
## Summary
Adds work experience, education, and certifications to the consultant onboarding flow — closing the gap with the web app's onboarding.

**Backend:**
- Extend `POST /api/onboarding/submit` to accept `workExperiences`, `education`, `certifications` arrays (created atomically in transaction)
- New `GET/PUT /api/user/:id/professional-background` route for post-onboarding management
- Register WorkExperience, Education, Certification models in schema registry

**Frontend:**
- New `ProfessionalBackgroundStep` with add/remove dialogs for each entry type
- Add Freezed sub-entities (`WorkExperienceEntry`, `EducationEntry`, `CertificationEntry`) to `ConsultantProfileData`
- Update `OnboardingState.totalSteps` (7 for consultants vs 6 for consultees)
- Update `canProceed` step index mapping for new step ordering
- Map professional background in `OnboardingRequestModel.fromState()`

Also adds `FEATURE_PARITY.md` tracking 186 features across 23 categories.

## Test plan
- [x] 300 backend tests pass (0 regressions)
- [x] `dart analyze` clean on all changed files
- [x] Freezed code regenerated successfully
- [ ] Manual test: consultant onboarding shows Background step between Profile and Availability
- [ ] Manual test: add/remove work experience, education, certification entries
- [ ] Manual test: submit onboarding with professional background creates records

🤖 Generated with [Claude Code](https://claude.com/claude-code)