### PR TITLE
feature: add trial session frontend

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -470,9 +470,17 @@ GoRouter router(Ref ref) {
             name: 'trialRequest',
             builder: (context, state) {
               final consultantProfileId =
-                  state.uri.queryParameters['consultantProfileId']!;
+                  state.uri.queryParameters['consultantProfileId'];
               final subscriptionPlanId =
-                  state.uri.queryParameters['subscriptionPlanId']!;
+                  state.uri.queryParameters['subscriptionPlanId'];
+              if (consultantProfileId == null ||
+                  subscriptionPlanId == null) {
+                return const Scaffold(
+                  body: Center(
+                    child: Text('Missing required parameters'),
+                  ),
+                );
+              }
               return TrialRequestScreen(
                 consultantProfileId: consultantProfileId,
                 subscriptionPlanId: subscriptionPlanId,

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -35,6 +35,8 @@ import '../features/support/screens/support_ticket_detail_screen.dart';
 import '../features/support/screens/create_ticket_screen.dart';
 import '../features/feedback/screens/feedback_screen.dart';
 import '../features/meetings/screens/meeting_screen.dart';
+import '../features/trials/screens/trial_list_screen.dart';
+import '../features/trials/screens/trial_request_screen.dart';
 import '../features/verification/screens/verification_status_screen.dart';
 import '../features/verification/screens/verification_submit_screen.dart';
 import 'providers/navigation_provider.dart';
@@ -453,6 +455,29 @@ GoRouter router(Ref ref) {
             name: 'verificationSubmit',
             builder: (context, state) =>
                 const VerificationSubmitScreen(),
+          ),
+        ],
+      ),
+
+      // Trial routes
+      GoRoute(
+        path: '/trials',
+        name: 'trials',
+        builder: (context, state) => const TrialListScreen(),
+        routes: [
+          GoRoute(
+            path: 'request',
+            name: 'trialRequest',
+            builder: (context, state) {
+              final consultantProfileId =
+                  state.uri.queryParameters['consultantProfileId']!;
+              final subscriptionPlanId =
+                  state.uri.queryParameters['subscriptionPlanId']!;
+              return TrialRequestScreen(
+                consultantProfileId: consultantProfileId,
+                subscriptionPlanId: subscriptionPlanId,
+              );
+            },
           ),
         ],
       ),

--- a/lib/data/datasources/remote/trial_remote_source.dart
+++ b/lib/data/datasources/remote/trial_remote_source.dart
@@ -23,7 +23,7 @@ abstract class TrialRemoteSource {
   Future<TrialSession> getTrialById(String trialId);
   Future<TrialSession> updateTrialStatus({
     required String trialId,
-    required String status,
+    required TrialStatus status,
   });
   Future<TrialEligibility> checkEligibility(String consultantProfileId);
   Future<TrialStats> getStats();
@@ -94,12 +94,12 @@ class TrialRemoteSourceImpl implements TrialRemoteSource {
   @override
   Future<TrialSession> updateTrialStatus({
     required String trialId,
-    required String status,
+    required TrialStatus status,
   }) async {
     try {
       final response = await _dio.put(
         '/api/trials/$trialId',
-        data: {'status': status},
+        data: {'status': status.name.toUpperCase()},
       );
       return TrialSession.fromJson(
         response.data['data'] as Map<String, dynamic>,

--- a/lib/data/datasources/remote/trial_remote_source.dart
+++ b/lib/data/datasources/remote/trial_remote_source.dart
@@ -1,0 +1,149 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/errors/exceptions.dart';
+import '../../../domain/entities/trial/trial_entities.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'trial_remote_source.g.dart';
+
+@riverpod
+TrialRemoteSource trialRemoteSource(Ref ref) {
+  return TrialRemoteSourceImpl(ref.watch(dioProvider));
+}
+
+abstract class TrialRemoteSource {
+  Future<List<TrialSession>> getTrials();
+  Future<TrialSession> requestTrial({
+    required String consultantProfileId,
+    required String subscriptionPlanId,
+    String? notes,
+  });
+  Future<TrialSession> getTrialById(String trialId);
+  Future<TrialSession> updateTrialStatus({
+    required String trialId,
+    required String status,
+  });
+  Future<TrialEligibility> checkEligibility(String consultantProfileId);
+  Future<TrialStats> getStats();
+}
+
+class TrialRemoteSourceImpl implements TrialRemoteSource {
+  final Dio _dio;
+
+  TrialRemoteSourceImpl(this._dio);
+
+  @override
+  Future<List<TrialSession>> getTrials() async {
+    try {
+      final response = await _dio.get('/api/trials');
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((d) => TrialSession.fromJson(d as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to load trials',
+      );
+    }
+  }
+
+  @override
+  Future<TrialSession> requestTrial({
+    required String consultantProfileId,
+    required String subscriptionPlanId,
+    String? notes,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/api/trials',
+        data: {
+          'consultantProfileId': consultantProfileId,
+          'subscriptionPlanId': subscriptionPlanId,
+          'notes': notes,
+        },
+      );
+      return TrialSession.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to request trial',
+      );
+    }
+  }
+
+  @override
+  Future<TrialSession> getTrialById(String trialId) async {
+    try {
+      final response = await _dio.get('/api/trials/$trialId');
+      return TrialSession.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to load trial',
+      );
+    }
+  }
+
+  @override
+  Future<TrialSession> updateTrialStatus({
+    required String trialId,
+    required String status,
+  }) async {
+    try {
+      final response = await _dio.put(
+        '/api/trials/$trialId',
+        data: {'status': status},
+      );
+      return TrialSession.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to update trial',
+      );
+    }
+  }
+
+  @override
+  Future<TrialEligibility> checkEligibility(
+    String consultantProfileId,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/api/trials/check-eligibility',
+        queryParameters: {'consultantProfileId': consultantProfileId},
+      );
+      return TrialEligibility.fromJson(
+        response.data as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to check eligibility',
+      );
+    }
+  }
+
+  @override
+  Future<TrialStats> getStats() async {
+    try {
+      final response = await _dio.get('/api/trials/stats');
+      return TrialStats.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to load stats',
+      );
+    }
+  }
+}

--- a/lib/domain/entities/trial/trial_entities.dart
+++ b/lib/domain/entities/trial/trial_entities.dart
@@ -1,0 +1,5 @@
+/// Trial domain entities
+library;
+
+export 'trial_session.dart';
+export 'trial_status.dart';

--- a/lib/domain/entities/trial/trial_session.dart
+++ b/lib/domain/entities/trial/trial_session.dart
@@ -1,0 +1,52 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'trial_status.dart';
+
+part 'trial_session.freezed.dart';
+part 'trial_session.g.dart';
+
+@freezed
+class TrialSession with _$TrialSession {
+  const factory TrialSession({
+    required String id,
+    required TrialStatus status,
+    String? notes,
+    required String consulteeProfileId,
+    required String consultantProfileId,
+    required String subscriptionPlanId,
+    String? appointmentId,
+    String? convertedToSubscriptionId,
+    required DateTime requestedAt,
+    DateTime? completedAt,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _TrialSession;
+
+  factory TrialSession.fromJson(Map<String, dynamic> json) =>
+      _$TrialSessionFromJson(json);
+}
+
+@freezed
+class TrialEligibility with _$TrialEligibility {
+  const factory TrialEligibility({
+    required bool eligible,
+    String? reason,
+  }) = _TrialEligibility;
+
+  factory TrialEligibility.fromJson(Map<String, dynamic> json) =>
+      _$TrialEligibilityFromJson(json);
+}
+
+@freezed
+class TrialStats with _$TrialStats {
+  const factory TrialStats({
+    @Default(0) int total,
+    @Default(0) int pending,
+    @Default(0) int completed,
+    @Default(0) int converted,
+    @Default(0) int conversionRate,
+  }) = _TrialStats;
+
+  factory TrialStats.fromJson(Map<String, dynamic> json) =>
+      _$TrialStatsFromJson(json);
+}

--- a/lib/domain/entities/trial/trial_status.dart
+++ b/lib/domain/entities/trial/trial_status.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+enum TrialStatus {
+  @JsonValue('PENDING')
+  pending,
+  @JsonValue('SCHEDULED')
+  scheduled,
+  @JsonValue('COMPLETED')
+  completed,
+  @JsonValue('CONVERTED')
+  converted,
+  @JsonValue('CANCELLED')
+  cancelled,
+  @JsonValue('REJECTED')
+  rejected,
+}
+
+extension TrialStatusX on TrialStatus {
+  String get displayLabel => switch (this) {
+        TrialStatus.pending => 'Pending',
+        TrialStatus.scheduled => 'Scheduled',
+        TrialStatus.completed => 'Completed',
+        TrialStatus.converted => 'Converted',
+        TrialStatus.cancelled => 'Cancelled',
+        TrialStatus.rejected => 'Rejected',
+      };
+
+  bool get isPending => this == TrialStatus.pending;
+  bool get isActive =>
+      this == TrialStatus.pending || this == TrialStatus.scheduled;
+}

--- a/lib/features/trials/providers/trial_provider.dart
+++ b/lib/features/trials/providers/trial_provider.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../../../data/datasources/remote/trial_remote_source.dart';
+import '../../../domain/entities/trial/trial_entities.dart';
+
+part 'trial_provider.g.dart';
+
+/// Provider for user's trial sessions list
+@riverpod
+class TrialList extends _$TrialList {
+  @override
+  Future<List<TrialSession>> build() async {
+    final source = ref.read(trialRemoteSourceProvider);
+    return source.getTrials();
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    try {
+      final source = ref.read(trialRemoteSourceProvider);
+      state = AsyncData(await source.getTrials());
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'TrialList.refresh',
+      );
+      state = AsyncError(e, stack);
+    }
+  }
+
+  /// Request a new trial and add it to the list
+  Future<TrialSession?> requestTrial({
+    required String consultantProfileId,
+    required String subscriptionPlanId,
+    String? notes,
+  }) async {
+    try {
+      final source = ref.read(trialRemoteSourceProvider);
+      final trial = await source.requestTrial(
+        consultantProfileId: consultantProfileId,
+        subscriptionPlanId: subscriptionPlanId,
+        notes: notes,
+      );
+      final current = state.valueOrNull ?? [];
+      state = AsyncData([trial, ...current]);
+      return trial;
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'TrialList.requestTrial',
+      );
+      rethrow;
+    }
+  }
+
+  /// Update a trial's status (accept/reject for consultants)
+  Future<void> updateStatus({
+    required String trialId,
+    required String status,
+  }) async {
+    try {
+      final source = ref.read(trialRemoteSourceProvider);
+      final updated =
+          await source.updateTrialStatus(trialId: trialId, status: status);
+      final current = state.valueOrNull ?? [];
+      state = AsyncData(
+        current.map((t) => t.id == trialId ? updated : t).toList(),
+      );
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'TrialList.updateStatus',
+      );
+      rethrow;
+    }
+  }
+}
+
+/// Provider to check trial eligibility for a specific consultant
+@riverpod
+Future<TrialEligibility> trialEligibility(
+  Ref ref,
+  String consultantProfileId,
+) async {
+  final source = ref.read(trialRemoteSourceProvider);
+  return source.checkEligibility(consultantProfileId);
+}
+
+/// Provider for consultant's trial stats
+@riverpod
+Future<TrialStats> trialStats(Ref ref) async {
+  final source = ref.read(trialRemoteSourceProvider);
+  return source.getStats();
+}

--- a/lib/features/trials/providers/trial_provider.dart
+++ b/lib/features/trials/providers/trial_provider.dart
@@ -32,7 +32,7 @@ class TrialList extends _$TrialList {
   }
 
   /// Request a new trial and add it to the list
-  Future<TrialSession?> requestTrial({
+  Future<TrialSession> requestTrial({
     required String consultantProfileId,
     required String subscriptionPlanId,
     String? notes,
@@ -60,7 +60,7 @@ class TrialList extends _$TrialList {
   /// Update a trial's status (accept/reject for consultants)
   Future<void> updateStatus({
     required String trialId,
-    required String status,
+    required TrialStatus status,
   }) async {
     try {
       final source = ref.read(trialRemoteSourceProvider);

--- a/lib/features/trials/screens/trial_list_screen.dart
+++ b/lib/features/trials/screens/trial_list_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../domain/entities/trial/trial_entities.dart';
+import '../../../domain/entities/trial/trial_status.dart';
 import '../providers/trial_provider.dart';
 import '../widgets/trial_card.dart';
 
@@ -43,13 +44,13 @@ class TrialListScreen extends ConsumerWidget {
                     ref,
                     context,
                     trial.id,
-                    'SCHEDULED',
+                    TrialStatus.scheduled,
                   ),
                   onReject: () => _updateStatus(
                     ref,
                     context,
                     trial.id,
-                    'REJECTED',
+                    TrialStatus.rejected,
                   ),
                 );
               },
@@ -79,7 +80,7 @@ class TrialListScreen extends ConsumerWidget {
     WidgetRef ref,
     BuildContext context,
     String trialId,
-    String status,
+    TrialStatus status,
   ) async {
     try {
       await ref
@@ -87,7 +88,7 @@ class TrialListScreen extends ConsumerWidget {
           .updateStatus(trialId: trialId, status: status);
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Trial ${status.toLowerCase()}')),
+          SnackBar(content: Text('Trial ${status.displayLabel}')),
         );
       }
     } catch (e) {

--- a/lib/features/trials/screens/trial_list_screen.dart
+++ b/lib/features/trials/screens/trial_list_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../domain/entities/trial/trial_entities.dart';
+import '../providers/trial_provider.dart';
+import '../widgets/trial_card.dart';
+
+class TrialListScreen extends ConsumerWidget {
+  const TrialListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trialsAsync = ref.watch(trialListProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Trial Sessions')),
+      body: trialsAsync.when(
+        data: (trials) {
+          if (trials.isEmpty) {
+            return const Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.science_outlined, size: 64, color: Colors.grey),
+                  SizedBox(height: 16),
+                  Text('No trial sessions yet'),
+                ],
+              ),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: () =>
+                ref.read(trialListProvider.notifier).refresh(),
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: trials.length,
+              itemBuilder: (context, index) {
+                final trial = trials[index];
+                return TrialCard(
+                  trial: trial,
+                  showActions: trial.status.isPending,
+                  onAccept: () => _updateStatus(
+                    ref,
+                    context,
+                    trial.id,
+                    'SCHEDULED',
+                  ),
+                  onReject: () => _updateStatus(
+                    ref,
+                    context,
+                    trial.id,
+                    'REJECTED',
+                  ),
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Error: $error'),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () =>
+                    ref.read(trialListProvider.notifier).refresh(),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _updateStatus(
+    WidgetRef ref,
+    BuildContext context,
+    String trialId,
+    String status,
+  ) async {
+    try {
+      await ref
+          .read(trialListProvider.notifier)
+          .updateStatus(trialId: trialId, status: status);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Trial ${status.toLowerCase()}')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed: $e')),
+        );
+      }
+    }
+  }
+}

--- a/lib/features/trials/screens/trial_request_screen.dart
+++ b/lib/features/trials/screens/trial_request_screen.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../providers/trial_provider.dart';
+
+/// Screen for a consultee to request a trial with a consultant.
+///
+/// Receives consultantProfileId and subscriptionPlanId as parameters.
+class TrialRequestScreen extends ConsumerStatefulWidget {
+  const TrialRequestScreen({
+    required this.consultantProfileId,
+    required this.subscriptionPlanId,
+    super.key,
+  });
+
+  final String consultantProfileId;
+  final String subscriptionPlanId;
+
+  @override
+  ConsumerState<TrialRequestScreen> createState() =>
+      _TrialRequestScreenState();
+}
+
+class _TrialRequestScreenState extends ConsumerState<TrialRequestScreen> {
+  final _notesController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final eligibilityAsync = ref.watch(
+      trialEligibilityProvider(widget.consultantProfileId),
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Request Trial')),
+      body: eligibilityAsync.when(
+        data: (eligibility) {
+          if (!eligibility.eligible) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.info_outline,
+                      size: 64,
+                      color: Colors.orange,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Not Eligible',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      eligibility.reason ?? 'You are not eligible '
+                          'for a trial with this consultant.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Request a Free Trial',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'You can have one free trial per consultant. '
+                  'The consultant will review your request and '
+                  'schedule a session.',
+                ),
+                const SizedBox(height: 24),
+                TextField(
+                  controller: _notesController,
+                  decoration: const InputDecoration(
+                    labelText: 'Notes (optional)',
+                    hintText: 'What would you like to discuss?',
+                    border: OutlineInputBorder(),
+                  ),
+                  maxLines: 4,
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: _isSubmitting ? null : _submit,
+                    child: _isSubmitting
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Text('Request Trial'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _isSubmitting = true);
+    try {
+      await ref.read(trialListProvider.notifier).requestTrial(
+            consultantProfileId: widget.consultantProfileId,
+            subscriptionPlanId: widget.subscriptionPlanId,
+            notes: _notesController.text.isEmpty
+                ? null
+                : _notesController.text,
+          );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Trial request submitted')),
+        );
+        context.pop();
+      }
+    } catch (e, stack) {
+      AppSentryLogger.captureException(
+        e,
+        stackTrace: stack,
+        context: 'TrialRequest._submit',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+}

--- a/lib/features/trials/widgets/trial_card.dart
+++ b/lib/features/trials/widgets/trial_card.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../domain/entities/trial/trial_entities.dart';
+
+class TrialCard extends StatelessWidget {
+  const TrialCard({
+    required this.trial,
+    this.onTap,
+    this.onAccept,
+    this.onReject,
+    this.showActions = false,
+    super.key,
+  });
+
+  final TrialSession trial;
+  final VoidCallback? onTap;
+  final VoidCallback? onAccept;
+  final VoidCallback? onReject;
+  final bool showActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (color, icon) = _statusDecoration(trial.status);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, size: 18, color: color),
+                  const SizedBox(width: 8),
+                  Chip(
+                    label: Text(
+                      trial.status.displayLabel,
+                      style: TextStyle(color: color, fontSize: 11),
+                    ),
+                    backgroundColor: color.withValues(alpha: 0.1),
+                    side: BorderSide.none,
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                  ),
+                  const Spacer(),
+                  Text(
+                    DateFormat.yMMMd().format(trial.createdAt),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+              if (trial.notes != null && trial.notes!.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Text(
+                  trial.notes!,
+                  style: theme.textTheme.bodyMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              if (showActions && trial.status.isPending) ...[
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    OutlinedButton(
+                      onPressed: onReject,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.red,
+                      ),
+                      child: const Text('Reject'),
+                    ),
+                    const SizedBox(width: 8),
+                    FilledButton(
+                      onPressed: onAccept,
+                      child: const Text('Accept'),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  (Color, IconData) _statusDecoration(TrialStatus status) => switch (status) {
+        TrialStatus.pending => (Colors.orange, Icons.hourglass_top),
+        TrialStatus.scheduled => (Colors.blue, Icons.event),
+        TrialStatus.completed => (Colors.green, Icons.check_circle),
+        TrialStatus.converted => (Colors.purple, Icons.star),
+        TrialStatus.cancelled => (Colors.grey, Icons.cancel),
+        TrialStatus.rejected => (Colors.red, Icons.block),
+      };
+}


### PR DESCRIPTION
## Summary
Full trial sessions UI following clean architecture:
- **Domain**: `TrialSession`, `TrialEligibility`, `TrialStats` (Freezed), `TrialStatus` enum
- **Data**: `TrialRemoteSource` (Dio) calling `/api/trials/*` endpoints
- **Providers**: `TrialList` (CRUD), `trialEligibility` (per-consultant), `trialStats`
- **Screens**: Trial list (view/accept/reject), Trial request (eligibility check + submit)
- **Widgets**: `TrialCard` (status decoration, notes, action buttons)
- **Routes**: `/trials`, `/trials/request`

## New Files (9)
| Layer | Files |
|-------|-------|
| Domain | `trial_entities.dart`, `trial_session.dart`, `trial_status.dart` |
| Data | `trial_remote_source.dart` |
| Feature | `trial_provider.dart`, `trial_list_screen.dart`, `trial_request_screen.dart`, `trial_card.dart` |

## Test plan
- [x] `dart analyze` clean (0 errors)
- [x] Build runner generates all Freezed + Riverpod code
- [ ] Manual test: /trials shows trial list
- [ ] Manual test: request trial from consultant profile
- [ ] Manual test: accept/reject trial as consultant

🤖 Generated with [Claude Code](https://claude.com/claude-code)