### PR TITLE
feature: add appointment document review backend

### DIFF
--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -113,6 +113,8 @@ class DatabaseClient {
         ConsultantVerificationRepository(_executor, _prisma);
     _trialRepository = TrialRepository(_executor, _prisma);
     _waitlistRepository = WaitlistRepository(_executor, _prisma);
+    _appointmentDocumentRepository =
+        AppointmentDocumentRepository(_executor, _prisma);
   }
 
   static DatabaseClient? _instance;
@@ -150,6 +152,8 @@ class DatabaseClient {
       _consultantVerificationRepository;
   late final TrialRepository _trialRepository;
   late final WaitlistRepository _waitlistRepository;
+  late final AppointmentDocumentRepository
+      _appointmentDocumentRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -288,6 +292,10 @@ class DatabaseClient {
 
   /// Waitlist repository (for webinar/class waitlists)
   WaitlistRepository get waitlists => _waitlistRepository;
+
+  /// Appointment document repository (for document review workflow)
+  AppointmentDocumentRepository get appointmentDocuments =>
+      _appointmentDocumentRepository;
 
   /// Execute raw SQL query and return results as maps
   Future<List<Map<String, dynamic>>> executeRaw(

--- a/backend/lib/database/repositories/appointment_document_repository.dart
+++ b/backend/lib/database/repositories/appointment_document_repository.dart
@@ -1,0 +1,95 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/generated/index.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for appointment document operations.
+///
+/// Uses JsonQueryBuilder for creates (foreign keys) and PrismaClient
+/// typed delegates for reads/updates.
+class AppointmentDocumentRepository extends BaseRepository {
+  AppointmentDocumentRepository(super._executor, this._prisma);
+
+  final PrismaClient _prisma;
+
+  /// Upload a document for an appointment.
+  Future<Map<String, dynamic>> create({
+    required String appointmentId,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+    String uploadedByRole = 'CONSULTEE',
+    String? responseToDocumentId,
+  }) async {
+    final now = nowIso8601;
+    final query = JsonQueryBuilder()
+        .model('AppointmentDocument')
+        .action(QueryAction.create)
+        .data({
+      'appointmentId': appointmentId,
+      'fileName': fileName,
+      'originalName': originalName,
+      'fileSize': fileSize,
+      'mimeType': mimeType,
+      'fileUrl': fileUrl,
+      'storagePath': storagePath,
+      'description': description,
+      'reviewStatus': 'PENDING',
+      'uploadedByRole': uploadedByRole,
+      'responseToDocumentId': responseToDocumentId,
+      'uploadedAt': now,
+      'updatedAt': now,
+    }).build();
+
+    final result = await executeQueryAsSingleMap(query);
+    if (result == null) throw Exception('Failed to create document');
+    return result;
+  }
+
+  /// Get all documents for an appointment.
+  Future<List<Map<String, dynamic>>> findByAppointment(
+    String appointmentId,
+  ) async {
+    final query = JsonQueryBuilder()
+        .model('AppointmentDocument')
+        .action(QueryAction.findMany)
+        .where({'appointmentId': appointmentId})
+        .build();
+    return executeQueryAsMaps(query);
+  }
+
+  /// Get a document by ID.
+  Future<AppointmentDocument?> findById(String id) async {
+    return _prisma.appointmentDocument.findUnique(
+      where: AppointmentDocumentWhereUniqueInput(id: id),
+    );
+  }
+
+  /// Update document review status (consultant reviews consultee doc).
+  Future<AppointmentDocument> updateReview({
+    required String id,
+    required DocumentReviewStatus status,
+    String? reviewNotes,
+    String? reviewedBy,
+  }) async {
+    return _prisma.appointmentDocument.update(
+      where: AppointmentDocumentWhereUniqueInput(id: id),
+      data: UpdateAppointmentDocumentInput(
+        reviewStatus: status,
+        reviewNotes: reviewNotes,
+        reviewedAt: DateTime.now().toUtc(),
+        reviewedBy: reviewedBy,
+      ),
+    );
+  }
+
+  /// Delete a document.
+  Future<void> delete(String id) async {
+    await _prisma.appointmentDocument.delete(
+      where: AppointmentDocumentWhereUniqueInput(id: id),
+    );
+  }
+}

--- a/backend/lib/database/repositories/appointment_document_repository.dart
+++ b/backend/lib/database/repositories/appointment_document_repository.dart
@@ -37,7 +37,7 @@ class AppointmentDocumentRepository extends BaseRepository {
       'fileUrl': fileUrl,
       'storagePath': storagePath,
       'description': description,
-      'reviewStatus': 'PENDING',
+      'reviewStatus': DocumentReviewStatus.pending.name,
       'uploadedByRole': uploadedByRole,
       'responseToDocumentId': responseToDocumentId,
       'uploadedAt': now,

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -4,6 +4,7 @@
 library;
 
 export 'account_repository.dart';
+export 'appointment_document_repository.dart';
 export 'appointment_repository.dart';
 export 'base_repository.dart';
 export 'checkout_repository.dart';

--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -2303,5 +2303,76 @@ SchemaRegistry buildSchemaRegistry() {
     },
   ));
 
+  // AppointmentDocument (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'AppointmentDocument',
+    tableName: 'AppointmentDocument',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'fileName': const FieldInfo(
+          name: 'fileName', columnName: 'fileName', type: 'String'),
+      'originalName': const FieldInfo(
+          name: 'originalName',
+          columnName: 'originalName',
+          type: 'String'),
+      'fileSize': const FieldInfo(
+          name: 'fileSize', columnName: 'fileSize', type: 'Int'),
+      'mimeType': const FieldInfo(
+          name: 'mimeType', columnName: 'mimeType', type: 'String'),
+      'fileUrl': const FieldInfo(
+          name: 'fileUrl', columnName: 'fileUrl', type: 'String'),
+      'storagePath': const FieldInfo(
+          name: 'storagePath',
+          columnName: 'storagePath',
+          type: 'String'),
+      'description': const FieldInfo(
+          name: 'description',
+          columnName: 'description',
+          type: 'String'),
+      'reviewStatus': const FieldInfo(
+          name: 'reviewStatus',
+          columnName: 'reviewStatus',
+          type: 'String'),
+      'reviewNotes': const FieldInfo(
+          name: 'reviewNotes',
+          columnName: 'reviewNotes',
+          type: 'String'),
+      'reviewedAt': const FieldInfo(
+          name: 'reviewedAt',
+          columnName: 'reviewedAt',
+          type: 'DateTime'),
+      'reviewedBy': const FieldInfo(
+          name: 'reviewedBy',
+          columnName: 'reviewedBy',
+          type: 'String'),
+      'uploadedByRole': const FieldInfo(
+          name: 'uploadedByRole',
+          columnName: 'uploadedByRole',
+          type: 'String'),
+      'responseToDocumentId': const FieldInfo(
+          name: 'responseToDocumentId',
+          columnName: 'responseToDocumentId',
+          type: 'String'),
+      'appointmentId': const FieldInfo(
+          name: 'appointmentId',
+          columnName: 'appointmentId',
+          type: 'String'),
+      'uploadedAt': const FieldInfo(
+          name: 'uploadedAt',
+          columnName: 'uploadedAt',
+          type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'appointment': RelationInfo.oneToOne(
+        name: 'appointment',
+        targetModel: 'Appointment',
+        foreignKey: 'appointmentId',
+        isOwner: true,
+      ),
+    },
+  ));
+
   return schema;
 }

--- a/backend/routes/api/appointments/[id]/documents/[docId]/index.dart
+++ b/backend/routes/api/appointments/[id]/documents/[docId]/index.dart
@@ -4,13 +4,11 @@ import 'package:backend/database/database_client.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
-/// GET /api/appointments/:id/documents/:docId — Document details
-/// PUT /api/appointments/:id/documents/:docId — Review document
-///   (consultant updates review status)
-/// DELETE /api/appointments/:id/documents/:docId — Remove document
-///
-/// PUT body: { "reviewStatus": "APPROVED"|"REJECTED"|..., "reviewNotes": "..." }
+/// GET /api/appointments/:id/documents/:docId — Details
+/// PUT /api/appointments/:id/documents/:docId — Review
+/// DELETE /api/appointments/:id/documents/:docId — Remove
 Future<Response> onRequest(
   RequestContext context,
   String id,
@@ -18,100 +16,21 @@ Future<Response> onRequest(
 ) async {
   final method = context.request.method;
 
-  if (method == HttpMethod.get) return _handleGet(context, docId);
-  if (method == HttpMethod.put) return _handlePut(context, docId);
-  if (method == HttpMethod.delete) return _handleDelete(context, docId);
+  if (method == HttpMethod.get) return _handle(context, id, docId, method);
+  if (method == HttpMethod.put) return _handle(context, id, docId, method);
+  if (method == HttpMethod.delete) {
+    return _handle(context, id, docId, method);
+  }
 
   return Response(statusCode: HttpStatus.methodNotAllowed);
 }
 
-Future<Response> _handleGet(RequestContext context, String docId) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final db = context.read<DatabaseClient>();
-    final doc = await db.appointmentDocuments.findById(docId);
-
-    if (doc == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Document not found'}},
-      );
-    }
-
-    return Response.json(body: {'data': doc.toJson()});
-  } catch (e, stackTrace) {
-    await SentryLogger.severe(
-      'Document get failed',
-      context: 'AppointmentDocGet',
-      error: e,
-      stackTrace: stackTrace,
-    );
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to get document'}},
-    );
-  }
-}
-
-Future<Response> _handlePut(RequestContext context, String docId) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final body = await context.request.json() as Map<String, dynamic>;
-    final reviewStatusStr = body['reviewStatus'] as String?;
-    final reviewNotes = body['reviewNotes'] as String?;
-
-    if (reviewStatusStr == null) {
-      return Response.json(
-        statusCode: HttpStatus.badRequest,
-        body: {'error': {'message': 'reviewStatus is required'}},
-      );
-    }
-
-    final reviewStatus = DocumentReviewStatus.values.firstWhere(
-      (s) => s.name.toUpperCase() == reviewStatusStr.toUpperCase(),
-      orElse: () => DocumentReviewStatus.pending,
-    );
-
-    final db = context.read<DatabaseClient>();
-    final updated = await db.appointmentDocuments.updateReview(
-      id: docId,
-      status: reviewStatus,
-      reviewNotes: reviewNotes,
-      reviewedBy: userId,
-    );
-
-    return Response.json(body: {'data': updated.toJson()});
-  } catch (e, stackTrace) {
-    await SentryLogger.severe(
-      'Document review failed',
-      context: 'AppointmentDocPut',
-      error: e,
-      stackTrace: stackTrace,
-    );
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to review document'}},
-    );
-  }
-}
-
-Future<Response> _handleDelete(
+/// Shared auth + authorization for all handlers.
+Future<Response> _handle(
   RequestContext context,
+  String appointmentId,
   String docId,
+  HttpMethod method,
 ) async {
   try {
     final userId = getUserIdFromToken(context);
@@ -122,20 +41,127 @@ Future<Response> _handleDelete(
       );
     }
 
+    // Verify user is a participant in the appointment
     final db = context.read<DatabaseClient>();
-    await db.appointmentDocuments.delete(docId);
+    final apptQuery = JsonQueryBuilder()
+        .model('Appointment')
+        .action(QueryAction.findFirst)
+        .where({'id': appointmentId})
+        .build();
+    final appointment = await db.executor.executeQueryAsSingleMap(
+      apptQuery,
+    );
+    if (appointment == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Appointment not found'}},
+      );
+    }
 
-    return Response.json(body: {'message': 'Document deleted'});
+    final user = await db.users.findById(userId);
+    final consulteeProfileId =
+        user?['consulteeProfileId'] as String?;
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    final apptConsulteeId =
+        appointment['consulteeProfileId'] as String?;
+    final apptConsultantId =
+        appointment['consultantProfileId'] as String?;
+
+    final isConsultee = consulteeProfileId != null &&
+        consulteeProfileId == apptConsulteeId;
+    final isConsultant = consultantProfileId != null &&
+        consultantProfileId == apptConsultantId;
+
+    if (!isConsultee && !isConsultant) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {
+          'error': {
+            'message': 'You are not a participant in this appointment',
+          },
+        },
+      );
+    }
+
+    if (method == HttpMethod.get) return _handleGet(db, docId);
+    if (method == HttpMethod.put) {
+      return _handlePut(context, db, docId, userId);
+    }
+    if (method == HttpMethod.delete) return _handleDelete(db, docId);
+    return Response(statusCode: HttpStatus.methodNotAllowed);
   } catch (e, stackTrace) {
     await SentryLogger.severe(
-      'Document delete failed',
-      context: 'AppointmentDocDelete',
+      'Document operation failed',
+      context: 'AppointmentDoc',
       error: e,
       stackTrace: stackTrace,
     );
     return Response.json(
       statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to delete document'}},
+      body: {'error': {'message': 'Operation failed'}},
     );
   }
+}
+
+Future<Response> _handleGet(DatabaseClient db, String docId) async {
+  final doc = await db.appointmentDocuments.findById(docId);
+  if (doc == null) {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'error': {'message': 'Document not found'}},
+    );
+  }
+  return Response.json(body: {'data': doc.toJson()});
+}
+
+Future<Response> _handlePut(
+  RequestContext context,
+  DatabaseClient db,
+  String docId,
+  String userId,
+) async {
+  final body = await context.request.json() as Map<String, dynamic>;
+  final reviewStatusStr = body['reviewStatus'] as String?;
+  final reviewNotes = body['reviewNotes'] as String?;
+
+  if (reviewStatusStr == null) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {'error': {'message': 'reviewStatus is required'}},
+    );
+  }
+
+  // Validate reviewStatus — return 400 for invalid values
+  final reviewStatus = DocumentReviewStatus.values
+      .cast<DocumentReviewStatus?>()
+      .firstWhere(
+        (s) => s!.name.toUpperCase() == reviewStatusStr.toUpperCase(),
+        orElse: () => null,
+      );
+
+  if (reviewStatus == null) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {
+        'error': {
+          'message': 'Invalid reviewStatus: "$reviewStatusStr"',
+        },
+      },
+    );
+  }
+
+  final updated = await db.appointmentDocuments.updateReview(
+    id: docId,
+    status: reviewStatus,
+    reviewNotes: reviewNotes,
+    reviewedBy: userId,
+  );
+
+  return Response.json(body: {'data': updated.toJson()});
+}
+
+Future<Response> _handleDelete(DatabaseClient db, String docId) async {
+  await db.appointmentDocuments.delete(docId);
+  return Response.json(body: {'message': 'Document deleted'});
 }

--- a/backend/routes/api/appointments/[id]/documents/[docId]/index.dart
+++ b/backend/routes/api/appointments/[id]/documents/[docId]/index.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/appointments/:id/documents/:docId — Document details
+/// PUT /api/appointments/:id/documents/:docId — Review document
+///   (consultant updates review status)
+/// DELETE /api/appointments/:id/documents/:docId — Remove document
+///
+/// PUT body: { "reviewStatus": "APPROVED"|"REJECTED"|..., "reviewNotes": "..." }
+Future<Response> onRequest(
+  RequestContext context,
+  String id,
+  String docId,
+) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context, docId);
+  if (method == HttpMethod.put) return _handlePut(context, docId);
+  if (method == HttpMethod.delete) return _handleDelete(context, docId);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context, String docId) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final doc = await db.appointmentDocuments.findById(docId);
+
+    if (doc == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Document not found'}},
+      );
+    }
+
+    return Response.json(body: {'data': doc.toJson()});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document get failed',
+      context: 'AppointmentDocGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get document'}},
+    );
+  }
+}
+
+Future<Response> _handlePut(RequestContext context, String docId) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final reviewStatusStr = body['reviewStatus'] as String?;
+    final reviewNotes = body['reviewNotes'] as String?;
+
+    if (reviewStatusStr == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'error': {'message': 'reviewStatus is required'}},
+      );
+    }
+
+    final reviewStatus = DocumentReviewStatus.values.firstWhere(
+      (s) => s.name.toUpperCase() == reviewStatusStr.toUpperCase(),
+      orElse: () => DocumentReviewStatus.pending,
+    );
+
+    final db = context.read<DatabaseClient>();
+    final updated = await db.appointmentDocuments.updateReview(
+      id: docId,
+      status: reviewStatus,
+      reviewNotes: reviewNotes,
+      reviewedBy: userId,
+    );
+
+    return Response.json(body: {'data': updated.toJson()});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document review failed',
+      context: 'AppointmentDocPut',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to review document'}},
+    );
+  }
+}
+
+Future<Response> _handleDelete(
+  RequestContext context,
+  String docId,
+) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    await db.appointmentDocuments.delete(docId);
+
+    return Response.json(body: {'message': 'Document deleted'});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document delete failed',
+      context: 'AppointmentDocDelete',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to delete document'}},
+    );
+  }
+}

--- a/backend/routes/api/appointments/[id]/documents/index.dart
+++ b/backend/routes/api/appointments/[id]/documents/index.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/appointments/:id/documents — List documents for an appointment
+/// POST /api/appointments/:id/documents — Upload a document
+///
+/// POST body:
+/// {
+///   "fileName": "resume.pdf",
+///   "originalName": "My Resume.pdf",
+///   "fileSize": 102400,
+///   "mimeType": "application/pdf",
+///   "fileUrl": "https://...",
+///   "storagePath": "userId/123.pdf",
+///   "description": "Resume for review",
+///   "uploadedByRole": "CONSULTEE" | "CONSULTANT",
+///   "responseToDocumentId": "optional-doc-id"
+/// }
+Future<Response> onRequest(RequestContext context, String id) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context, id);
+  if (method == HttpMethod.post) return _handlePost(context, id);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final docs = await db.appointmentDocuments.findByAppointment(id);
+
+    return Response.json(
+      body: {'data': docs.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document list failed',
+      context: 'AppointmentDocumentsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to list documents'}},
+    );
+  }
+}
+
+Future<Response> _handlePost(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+
+    final fileName = body['fileName'] as String?;
+    final originalName = body['originalName'] as String?;
+    final fileSize = body['fileSize'] as int?;
+    final mimeType = body['mimeType'] as String?;
+    final fileUrl = body['fileUrl'] as String?;
+    final storagePath = body['storagePath'] as String?;
+
+    if (fileName == null ||
+        originalName == null ||
+        fileSize == null ||
+        mimeType == null ||
+        fileUrl == null ||
+        storagePath == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'fileName, originalName, fileSize, mimeType, '
+                'fileUrl, and storagePath are required',
+          },
+        },
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final doc = await db.appointmentDocuments.create(
+      appointmentId: id,
+      fileName: fileName,
+      originalName: originalName,
+      fileSize: fileSize,
+      mimeType: mimeType,
+      fileUrl: fileUrl,
+      storagePath: storagePath,
+      description: body['description'] as String?,
+      uploadedByRole: body['uploadedByRole'] as String? ?? 'CONSULTEE',
+      responseToDocumentId:
+          body['responseToDocumentId'] as String?,
+    );
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': serializeForJson(doc)},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Document upload failed',
+      context: 'AppointmentDocumentsPost',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to upload document'}},
+    );
+  }
+}

--- a/backend/routes/api/appointments/[id]/documents/index.dart
+++ b/backend/routes/api/appointments/[id]/documents/index.dart
@@ -5,22 +5,10 @@ import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
-/// GET /api/appointments/:id/documents — List documents for an appointment
+/// GET /api/appointments/:id/documents — List documents
 /// POST /api/appointments/:id/documents — Upload a document
-///
-/// POST body:
-/// {
-///   "fileName": "resume.pdf",
-///   "originalName": "My Resume.pdf",
-///   "fileSize": 102400,
-///   "mimeType": "application/pdf",
-///   "fileUrl": "https://...",
-///   "storagePath": "userId/123.pdf",
-///   "description": "Resume for review",
-///   "uploadedByRole": "CONSULTEE" | "CONSULTANT",
-///   "responseToDocumentId": "optional-doc-id"
-/// }
 Future<Response> onRequest(RequestContext context, String id) async {
   final method = context.request.method;
 
@@ -28,6 +16,56 @@ Future<Response> onRequest(RequestContext context, String id) async {
   if (method == HttpMethod.post) return _handlePost(context, id);
 
   return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+/// Verify user is a participant in the appointment.
+/// Returns the user's role ('CONSULTEE'|'CONSULTANT') or a Response.
+Future<Object> _authorizeParticipant(
+  RequestContext context,
+  String appointmentId,
+  String userId,
+) async {
+  final db = context.read<DatabaseClient>();
+  final apptQuery = JsonQueryBuilder()
+      .model('Appointment')
+      .action(QueryAction.findFirst)
+      .where({'id': appointmentId})
+      .build();
+  final appointment = await db.executor.executeQueryAsSingleMap(
+    apptQuery,
+  );
+  if (appointment == null) {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'error': {'message': 'Appointment not found'}},
+    );
+  }
+
+  final user = await db.users.findById(userId);
+  final consulteeProfileId = user?['consulteeProfileId'] as String?;
+  final consultantProfileId = user?['consultantProfileId'] as String?;
+  final apptConsulteeId =
+      appointment['consulteeProfileId'] as String?;
+  final apptConsultantId =
+      appointment['consultantProfileId'] as String?;
+
+  if (consulteeProfileId != null &&
+      consulteeProfileId == apptConsulteeId) {
+    return 'CONSULTEE';
+  }
+  if (consultantProfileId != null &&
+      consultantProfileId == apptConsultantId) {
+    return 'CONSULTANT';
+  }
+
+  return Response.json(
+    statusCode: HttpStatus.forbidden,
+    body: {
+      'error': {
+        'message': 'You are not a participant in this appointment',
+      },
+    },
+  );
 }
 
 Future<Response> _handleGet(RequestContext context, String id) async {
@@ -39,6 +77,9 @@ Future<Response> _handleGet(RequestContext context, String id) async {
         body: {'error': {'message': 'Unauthorized'}},
       );
     }
+
+    final authResult = await _authorizeParticipant(context, id, userId);
+    if (authResult is Response) return authResult;
 
     final db = context.read<DatabaseClient>();
     final docs = await db.appointmentDocuments.findByAppointment(id);
@@ -70,8 +111,12 @@ Future<Response> _handlePost(RequestContext context, String id) async {
       );
     }
 
-    final body = await context.request.json() as Map<String, dynamic>;
+    // Authorize and determine role server-side (not from client)
+    final authResult = await _authorizeParticipant(context, id, userId);
+    if (authResult is Response) return authResult;
+    final uploadedByRole = authResult as String;
 
+    final body = await context.request.json() as Map<String, dynamic>;
     final fileName = body['fileName'] as String?;
     final originalName = body['originalName'] as String?;
     final fileSize = body['fileSize'] as int?;
@@ -106,7 +151,7 @@ Future<Response> _handlePost(RequestContext context, String id) async {
       fileUrl: fileUrl,
       storagePath: storagePath,
       description: body['description'] as String?,
-      uploadedByRole: body['uploadedByRole'] as String? ?? 'CONSULTEE',
+      uploadedByRole: uploadedByRole,
       responseToDocumentId:
           body['responseToDocumentId'] as String?,
     );


### PR DESCRIPTION
## Summary
Appointment document review system — consultees upload documents for review, consultants review and respond.

**Backend:**
- `AppointmentDocumentRepository` (create, findByAppointment, findById, updateReview, delete)
- Schema registry: AppointmentDocument model with all fields + Appointment relation
- `DatabaseClient.appointmentDocuments` accessor

**Routes:**
| Route | Method | Description |
|-------|--------|-------------|
| `/api/appointments/:id/documents` | GET | List documents |
| `/api/appointments/:id/documents` | POST | Upload document |
| `/api/appointments/:id/documents/:docId` | GET | Document details |
| `/api/appointments/:id/documents/:docId` | PUT | Review (status + notes) |
| `/api/appointments/:id/documents/:docId` | DELETE | Remove document |

**Features:**
- Supports both consultee and consultant uploads (via `uploadedByRole`)
- Document response linking (`responseToDocumentId`) for consultant replies
- Review workflow: PENDING → IN_REVIEW → APPROVED/REJECTED/NEEDS_REVISION

## Test plan
- [x] 300 backend tests pass (0 regressions)
- [x] `dart analyze` clean
- [ ] Manual: upload document to appointment
- [ ] Manual: consultant reviews document

🤖 Generated with [Claude Code](https://claude.com/claude-code)