### PR TITLE
feature: add payout account management backend

### DIFF
--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -113,6 +113,8 @@ class DatabaseClient {
         ConsultantVerificationRepository(_executor, _prisma);
     _trialRepository = TrialRepository(_executor, _prisma);
     _waitlistRepository = WaitlistRepository(_executor, _prisma);
+    _payoutAccountRepository =
+        PayoutAccountRepository(_executor, _prisma);
   }
 
   static DatabaseClient? _instance;
@@ -150,6 +152,7 @@ class DatabaseClient {
       _consultantVerificationRepository;
   late final TrialRepository _trialRepository;
   late final WaitlistRepository _waitlistRepository;
+  late final PayoutAccountRepository _payoutAccountRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -288,6 +291,10 @@ class DatabaseClient {
 
   /// Waitlist repository (for webinar/class waitlists)
   WaitlistRepository get waitlists => _waitlistRepository;
+
+  /// Payout account repository (for consultant bank/UPI accounts)
+  PayoutAccountRepository get payoutAccounts =>
+      _payoutAccountRepository;
 
   /// Execute raw SQL query and return results as maps
   Future<List<Map<String, dynamic>>> executeRaw(

--- a/backend/lib/database/repositories/payout_account_repository.dart
+++ b/backend/lib/database/repositories/payout_account_repository.dart
@@ -1,0 +1,119 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/generated/index.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for payout account operations.
+class PayoutAccountRepository extends BaseRepository {
+  PayoutAccountRepository(super._executor, this._prisma);
+
+  final PrismaClient _prisma;
+
+  /// Create a new payout account.
+  Future<Map<String, dynamic>> create({
+    required String consultantProfileId,
+    required String provider,
+    required String accountType,
+    String? accountHolderName,
+    String? bankName,
+    String? accountNumberLast4,
+    String? ifscCode,
+    String? upiId,
+    bool isDefault = false,
+  }) async {
+    final now = nowIso8601;
+    final query = JsonQueryBuilder()
+        .model('PayoutAccount')
+        .action(QueryAction.create)
+        .data({
+      'consultantProfileId': consultantProfileId,
+      'provider': provider,
+      'accountType': accountType,
+      'accountHolderName': accountHolderName,
+      'bankName': bankName,
+      'accountNumberLast4': accountNumberLast4,
+      'ifscCode': ifscCode,
+      'upiId': upiId,
+      'isVerified': false,
+      'isDefault': isDefault,
+      'createdAt': now,
+      'updatedAt': now,
+    }).build();
+
+    final result = await executeQueryAsSingleMap(query);
+    if (result == null) throw Exception('Failed to create payout account');
+    return result;
+  }
+
+  /// Get all payout accounts for a consultant.
+  Future<List<Map<String, dynamic>>> findByConsultant(
+    String consultantProfileId,
+  ) async {
+    final query = JsonQueryBuilder()
+        .model('PayoutAccount')
+        .action(QueryAction.findMany)
+        .where({'consultantProfileId': consultantProfileId})
+        .build();
+    return executeQueryAsMaps(query);
+  }
+
+  /// Get a payout account by ID.
+  Future<PayoutAccount?> findById(String id) async {
+    return _prisma.payoutAccount.findUnique(
+      where: PayoutAccountWhereUniqueInput(id: id),
+    );
+  }
+
+  /// Update a payout account.
+  Future<PayoutAccount> update({
+    required String id,
+    String? accountHolderName,
+    String? bankName,
+    String? accountNumberLast4,
+    String? ifscCode,
+    String? upiId,
+  }) async {
+    return _prisma.payoutAccount.update(
+      where: PayoutAccountWhereUniqueInput(id: id),
+      data: UpdatePayoutAccountInput(
+        accountHolderName: accountHolderName,
+        bankName: bankName,
+        accountNumberLast4: accountNumberLast4,
+        ifscCode: ifscCode,
+        upiId: upiId,
+      ),
+    );
+  }
+
+  /// Set an account as default (unset all others first).
+  Future<void> setDefault({
+    required String id,
+    required String consultantProfileId,
+  }) async {
+    await executeInTransaction((txn) async {
+      // Unset all defaults for this consultant
+      final unsetQuery = JsonQueryBuilder()
+          .model('PayoutAccount')
+          .action(QueryAction.updateMany)
+          .where({'consultantProfileId': consultantProfileId})
+          .data({'isDefault': false, 'updatedAt': nowIso8601})
+          .build();
+      await txn.executeMutation(unsetQuery);
+
+      // Set the new default
+      final setQuery = JsonQueryBuilder()
+          .model('PayoutAccount')
+          .action(QueryAction.update)
+          .where({'id': id})
+          .data({'isDefault': true, 'updatedAt': nowIso8601})
+          .build();
+      await txn.executeMutation(setQuery);
+    });
+  }
+
+  /// Delete a payout account.
+  Future<void> delete(String id) async {
+    await _prisma.payoutAccount.delete(
+      where: PayoutAccountWhereUniqueInput(id: id),
+    );
+  }
+}

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -26,6 +26,7 @@ export 'slot_repository.dart';
 export 'support_ticket_repository.dart';
 export 'trial_repository.dart';
 export 'user_repository.dart';
+export 'payout_account_repository.dart';
 export 'verification_repository.dart';
 export 'waitlist_repository.dart';
 export 'webhook_event_repository.dart';

--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -2303,5 +2303,72 @@ SchemaRegistry buildSchemaRegistry() {
     },
   ));
 
+  // PayoutAccount (no @@map)
+  schema.registerModel(ModelSchema(
+    name: 'PayoutAccount',
+    tableName: 'PayoutAccount',
+    fields: {
+      'id': FieldInfo.id(name: 'id'),
+      'consultantProfileId': const FieldInfo(
+          name: 'consultantProfileId',
+          columnName: 'consultantProfileId',
+          type: 'String'),
+      'provider': const FieldInfo(
+          name: 'provider', columnName: 'provider', type: 'String'),
+      'accountType': const FieldInfo(
+          name: 'accountType',
+          columnName: 'accountType',
+          type: 'String'),
+      'accountHolderName': const FieldInfo(
+          name: 'accountHolderName',
+          columnName: 'accountHolderName',
+          type: 'String'),
+      'bankName': const FieldInfo(
+          name: 'bankName', columnName: 'bankName', type: 'String'),
+      'accountNumberLast4': const FieldInfo(
+          name: 'accountNumberLast4',
+          columnName: 'accountNumberLast4',
+          type: 'String'),
+      'ifscCode': const FieldInfo(
+          name: 'ifscCode', columnName: 'ifscCode', type: 'String'),
+      'upiId': const FieldInfo(
+          name: 'upiId', columnName: 'upiId', type: 'String'),
+      'stripeAccountId': const FieldInfo(
+          name: 'stripeAccountId',
+          columnName: 'stripeAccountId',
+          type: 'String'),
+      'stripeAccountStatus': const FieldInfo(
+          name: 'stripeAccountStatus',
+          columnName: 'stripeAccountStatus',
+          type: 'String'),
+      'razorpayContactId': const FieldInfo(
+          name: 'razorpayContactId',
+          columnName: 'razorpayContactId',
+          type: 'String'),
+      'razorpayFundAccId': const FieldInfo(
+          name: 'razorpayFundAccId',
+          columnName: 'razorpayFundAccId',
+          type: 'String'),
+      'isVerified': const FieldInfo(
+          name: 'isVerified',
+          columnName: 'isVerified',
+          type: 'Boolean'),
+      'isDefault': const FieldInfo(
+          name: 'isDefault', columnName: 'isDefault', type: 'Boolean'),
+      'createdAt': const FieldInfo(
+          name: 'createdAt', columnName: 'createdAt', type: 'DateTime'),
+      'updatedAt': const FieldInfo(
+          name: 'updatedAt', columnName: 'updatedAt', type: 'DateTime'),
+    },
+    relations: {
+      'consultantProfile': RelationInfo.oneToOne(
+        name: 'consultantProfile',
+        targetModel: 'ConsultantProfile',
+        foreignKey: 'consultantProfileId',
+        isOwner: true,
+      ),
+    },
+  ));
+
   return schema;
 }

--- a/backend/routes/api/consultant/payout-accounts/[id]/index.dart
+++ b/backend/routes/api/consultant/payout-accounts/[id]/index.dart
@@ -11,88 +11,18 @@ import 'package:dart_frog/dart_frog.dart';
 Future<Response> onRequest(RequestContext context, String id) async {
   final method = context.request.method;
 
-  if (method == HttpMethod.get) return _handleGet(context, id);
-  if (method == HttpMethod.put) return _handlePut(context, id);
-  if (method == HttpMethod.delete) return _handleDelete(context, id);
+  if (method == HttpMethod.get) return _handle(context, id, method);
+  if (method == HttpMethod.put) return _handle(context, id, method);
+  if (method == HttpMethod.delete) return _handle(context, id, method);
 
   return Response(statusCode: HttpStatus.methodNotAllowed);
 }
 
-Future<Response> _handleGet(RequestContext context, String id) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final db = context.read<DatabaseClient>();
-    final account = await db.payoutAccounts.findById(id);
-
-    if (account == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Account not found'}},
-      );
-    }
-
-    return Response.json(body: {'data': account.toJson()});
-  } catch (e, stackTrace) {
-    await SentryLogger.severe(
-      'Payout account get failed',
-      context: 'PayoutAccountGet',
-      error: e,
-      stackTrace: stackTrace,
-    );
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to get account'}},
-    );
-  }
-}
-
-Future<Response> _handlePut(RequestContext context, String id) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final body = await context.request.json() as Map<String, dynamic>;
-    final db = context.read<DatabaseClient>();
-
-    final updated = await db.payoutAccounts.update(
-      id: id,
-      accountHolderName: body['accountHolderName'] as String?,
-      bankName: body['bankName'] as String?,
-      accountNumberLast4: body['accountNumberLast4'] as String?,
-      ifscCode: body['ifscCode'] as String?,
-      upiId: body['upiId'] as String?,
-    );
-
-    return Response.json(body: {'data': updated.toJson()});
-  } catch (e, stackTrace) {
-    await SentryLogger.severe(
-      'Payout account update failed',
-      context: 'PayoutAccountPut',
-      error: e,
-      stackTrace: stackTrace,
-    );
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to update account'}},
-    );
-  }
-}
-
-Future<Response> _handleDelete(
+/// Shared auth + ownership verification for all handlers.
+Future<Response> _handle(
   RequestContext context,
   String id,
+  HttpMethod method,
 ) async {
   try {
     final userId = getUserIdFromToken(context);
@@ -104,19 +34,75 @@ Future<Response> _handleDelete(
     }
 
     final db = context.read<DatabaseClient>();
-    await db.payoutAccounts.delete(id);
 
+    // Get user's consultant profile ID
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can manage payouts'},
+        },
+      );
+    }
+
+    // Fetch account and verify ownership
+    final account = await db.payoutAccounts.findById(id);
+    if (account == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Account not found'}},
+      );
+    }
+
+    final accountJson = account.toJson();
+    if (accountJson['consultantProfileId'] != consultantProfileId) {
+      // Return 404 to avoid leaking that the account exists
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Account not found'}},
+      );
+    }
+
+    // Dispatch to handler
+    if (method == HttpMethod.get) {
+      return Response.json(body: {'data': accountJson});
+    }
+    if (method == HttpMethod.put) {
+      return _handlePut(context, db, id);
+    }
+    // DELETE
+    await db.payoutAccounts.delete(id);
     return Response.json(body: {'message': 'Account deleted'});
   } catch (e, stackTrace) {
     await SentryLogger.severe(
-      'Payout account delete failed',
-      context: 'PayoutAccountDelete',
+      'Payout account operation failed',
+      context: 'PayoutAccount',
       error: e,
       stackTrace: stackTrace,
     );
     return Response.json(
       statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to delete account'}},
+      body: {'error': {'message': 'Operation failed'}},
     );
   }
+}
+
+Future<Response> _handlePut(
+  RequestContext context,
+  DatabaseClient db,
+  String id,
+) async {
+  final body = await context.request.json() as Map<String, dynamic>;
+  final updated = await db.payoutAccounts.update(
+    id: id,
+    accountHolderName: body['accountHolderName'] as String?,
+    bankName: body['bankName'] as String?,
+    accountNumberLast4: body['accountNumberLast4'] as String?,
+    ifscCode: body['ifscCode'] as String?,
+    upiId: body['upiId'] as String?,
+  );
+  return Response.json(body: {'data': updated.toJson()});
 }

--- a/backend/routes/api/consultant/payout-accounts/[id]/index.dart
+++ b/backend/routes/api/consultant/payout-accounts/[id]/index.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/consultant/payout-accounts/:id — Account details
+/// PUT /api/consultant/payout-accounts/:id — Update account
+/// DELETE /api/consultant/payout-accounts/:id — Remove account
+Future<Response> onRequest(RequestContext context, String id) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context, id);
+  if (method == HttpMethod.put) return _handlePut(context, id);
+  if (method == HttpMethod.delete) return _handleDelete(context, id);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final account = await db.payoutAccounts.findById(id);
+
+    if (account == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Account not found'}},
+      );
+    }
+
+    return Response.json(body: {'data': account.toJson()});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Payout account get failed',
+      context: 'PayoutAccountGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get account'}},
+    );
+  }
+}
+
+Future<Response> _handlePut(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final db = context.read<DatabaseClient>();
+
+    final updated = await db.payoutAccounts.update(
+      id: id,
+      accountHolderName: body['accountHolderName'] as String?,
+      bankName: body['bankName'] as String?,
+      accountNumberLast4: body['accountNumberLast4'] as String?,
+      ifscCode: body['ifscCode'] as String?,
+      upiId: body['upiId'] as String?,
+    );
+
+    return Response.json(body: {'data': updated.toJson()});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Payout account update failed',
+      context: 'PayoutAccountPut',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to update account'}},
+    );
+  }
+}
+
+Future<Response> _handleDelete(
+  RequestContext context,
+  String id,
+) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    await db.payoutAccounts.delete(id);
+
+    return Response.json(body: {'message': 'Account deleted'});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Payout account delete failed',
+      context: 'PayoutAccountDelete',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to delete account'}},
+    );
+  }
+}

--- a/backend/routes/api/consultant/payout-accounts/[id]/set-default.dart
+++ b/backend/routes/api/consultant/payout-accounts/[id]/set-default.dart
@@ -33,6 +33,22 @@ Future<Response> onRequest(RequestContext context, String id) async {
       );
     }
 
+    // Verify the account belongs to this consultant
+    final account = await db.payoutAccounts.findById(id);
+    if (account == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Account not found'}},
+      );
+    }
+    final acctJson = account.toJson();
+    if (acctJson['consultantProfileId'] != consultantProfileId) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Account not found'}},
+      );
+    }
+
     await db.payoutAccounts.setDefault(
       id: id,
       consultantProfileId: consultantProfileId,

--- a/backend/routes/api/consultant/payout-accounts/[id]/set-default.dart
+++ b/backend/routes/api/consultant/payout-accounts/[id]/set-default.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// POST /api/consultant/payout-accounts/:id/set-default
+Future<Response> onRequest(RequestContext context, String id) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can set defaults'},
+        },
+      );
+    }
+
+    await db.payoutAccounts.setDefault(
+      id: id,
+      consultantProfileId: consultantProfileId,
+    );
+
+    return Response.json(
+      body: {'message': 'Default payout account updated'},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Set default payout account failed',
+      context: 'PayoutAccountSetDefault',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'error': {'message': 'Failed to set default account'},
+      },
+    );
+  }
+}

--- a/backend/routes/api/consultant/payout-accounts/index.dart
+++ b/backend/routes/api/consultant/payout-accounts/index.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/consultant/payout-accounts — List payout accounts
+/// POST /api/consultant/payout-accounts — Add new account
+Future<Response> onRequest(RequestContext context) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context);
+  if (method == HttpMethod.post) return _handlePost(context);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can manage payouts'},
+        },
+      );
+    }
+
+    final accounts =
+        await db.payoutAccounts.findByConsultant(consultantProfileId);
+
+    return Response.json(
+      body: {'data': accounts.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Payout accounts list failed',
+      context: 'PayoutAccountsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to list payout accounts'}},
+    );
+  }
+}
+
+Future<Response> _handlePost(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can add payouts'},
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final provider = body['provider'] as String? ?? 'RAZORPAY';
+    final accountType =
+        body['accountType'] as String? ?? 'BANK_ACCOUNT';
+
+    final account = await db.payoutAccounts.create(
+      consultantProfileId: consultantProfileId,
+      provider: provider,
+      accountType: accountType,
+      accountHolderName: body['accountHolderName'] as String?,
+      bankName: body['bankName'] as String?,
+      accountNumberLast4: body['accountNumberLast4'] as String?,
+      ifscCode: body['ifscCode'] as String?,
+      upiId: body['upiId'] as String?,
+    );
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': serializeForJson(account)},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Payout account creation failed',
+      context: 'PayoutAccountsPost',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to create payout account'}},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Payout account management for consultants — bank accounts, UPI, and gateway-specific fields.

**Backend:**
- `PayoutAccountRepository` (create, findByConsultant, findById, update, setDefault, delete)
- `setDefault` uses transaction to atomically unset all defaults then set new one
- Schema registry: PayoutAccount model with all fields + ConsultantProfile relation
- `DatabaseClient.payoutAccounts` accessor

**Routes:**
| Route | Method | Description |
|-------|--------|-------------|
| `/api/consultant/payout-accounts` | GET | List accounts |
| `/api/consultant/payout-accounts` | POST | Create account |
| `/api/consultant/payout-accounts/:id` | GET/PUT/DELETE | CRUD |
| `/api/consultant/payout-accounts/:id/set-default` | POST | Set default |

## Test plan
- [x] Backend tests pass (0 regressions)
- [x] `dart analyze` clean
- [ ] Manual: create bank account
- [ ] Manual: set default payout account

🤖 Generated with [Claude Code](https://claude.com/claude-code)