### PR TITLE
feature: Phase 5 — announcements, maintenance, recordings, support attachments

### DIFF
--- a/backend/lib/database/database_client.dart
+++ b/backend/lib/database/database_client.dart
@@ -117,6 +117,9 @@ class DatabaseClient {
         PayoutAccountRepository(_executor, _prisma);
     _appointmentDocumentRepository =
         AppointmentDocumentRepository(_executor, _prisma);
+    _announcementRepository = AnnouncementRepository(_executor);
+    _maintenanceRepository = MaintenanceRepository(_executor);
+    _recordingRepository = RecordingRepository(_executor, _prisma);
   }
 
   static DatabaseClient? _instance;
@@ -157,6 +160,9 @@ class DatabaseClient {
   late final PayoutAccountRepository _payoutAccountRepository;
   late final AppointmentDocumentRepository
       _appointmentDocumentRepository;
+  late final AnnouncementRepository _announcementRepository;
+  late final MaintenanceRepository _maintenanceRepository;
+  late final RecordingRepository _recordingRepository;
 
   /// Initialize the database client with a connection URL
   static Future<DatabaseClient> initialize(String connectionUrl) async {
@@ -303,6 +309,15 @@ class DatabaseClient {
   /// Appointment document repository (for document review workflow)
   AppointmentDocumentRepository get appointmentDocuments =>
       _appointmentDocumentRepository;
+
+  /// Announcement repository (read-only on mobile)
+  AnnouncementRepository get announcements => _announcementRepository;
+
+  /// Maintenance window repository (read-only)
+  MaintenanceRepository get maintenance => _maintenanceRepository;
+
+  /// Recording repository (for meeting recordings)
+  RecordingRepository get recordings => _recordingRepository;
 
   /// Execute raw SQL query and return results as maps
   Future<List<Map<String, dynamic>>> executeRaw(

--- a/backend/lib/database/repositories/announcement_repository.dart
+++ b/backend/lib/database/repositories/announcement_repository.dart
@@ -1,0 +1,24 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for announcement operations (read-only on mobile).
+class AnnouncementRepository extends BaseRepository {
+  AnnouncementRepository(super._executor);
+
+  /// Get active announcements (within date range, active status).
+  Future<List<Map<String, dynamic>>> getActive() async {
+    final now = nowIso8601;
+    final query = JsonQueryBuilder()
+        .model('announcements')
+        .action(QueryAction.findMany)
+        .where({
+      'isActive': true,
+      'startDate': {'lte': now},
+      'OR': [
+        {'endDate': null},
+        {'endDate': {'gte': now}},
+      ],
+    }).build();
+    return executeQueryAsMaps(query);
+  }
+}

--- a/backend/lib/database/repositories/maintenance_repository.dart
+++ b/backend/lib/database/repositories/maintenance_repository.dart
@@ -1,0 +1,21 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for maintenance window operations (read-only).
+class MaintenanceRepository extends BaseRepository {
+  MaintenanceRepository(super._executor);
+
+  /// Get the current active maintenance window (if any).
+  Future<Map<String, dynamic>?> getActive() async {
+    final now = nowIso8601;
+    final query = JsonQueryBuilder()
+        .model('maintenance_windows')
+        .action(QueryAction.findFirst)
+        .where({
+      'isActive': true,
+      'startTime': {'lte': now},
+      'endTime': {'gte': now},
+    }).build();
+    return executeQueryAsSingleMap(query);
+  }
+}

--- a/backend/lib/database/repositories/recording_repository.dart
+++ b/backend/lib/database/repositories/recording_repository.dart
@@ -1,0 +1,57 @@
+import 'package:backend/database/repositories/base_repository.dart';
+import 'package:backend/generated/index.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// Repository for meeting recording operations.
+class RecordingRepository extends BaseRepository {
+  RecordingRepository(super._executor, this._prisma);
+
+  final PrismaClient _prisma;
+
+  /// Get a recording by ID.
+  Future<Recording?> findById(String id) async {
+    return _prisma.recording.findUnique(
+      where: RecordingWhereUniqueInput(id: id),
+    );
+  }
+
+  /// Get recordings for a meeting session.
+  Future<List<Recording>> findByMeetingSession(
+    String meetingSessionId,
+  ) async {
+    return _prisma.recording.findMany(
+      where: RecordingWhereInput(
+        meetingSessionId: StringFilter(equals: meetingSessionId),
+      ),
+    );
+  }
+
+  /// Update recording metadata (e.g., after transfer to Supabase).
+  Future<Map<String, dynamic>?> updateMetadata({
+    required String id,
+    String? storageUrl,
+    String? storagePath,
+    String? transferStatus,
+    int? fileSize,
+    int? duration,
+  }) async {
+    final data = <String, dynamic>{
+      'updatedAt': nowIso8601,
+    };
+    if (storageUrl != null) data['storageUrl'] = storageUrl;
+    if (storagePath != null) data['storagePath'] = storagePath;
+    if (transferStatus != null) {
+      data['transferStatus'] = transferStatus;
+    }
+    if (fileSize != null) data['fileSize'] = fileSize;
+    if (duration != null) data['duration'] = duration;
+
+    final query = JsonQueryBuilder()
+        .model('Recording')
+        .action(QueryAction.update)
+        .where({'id': id})
+        .data(data)
+        .build();
+    return executeQueryAsSingleMap(query);
+  }
+}

--- a/backend/lib/database/repositories/repositories.dart
+++ b/backend/lib/database/repositories/repositories.dart
@@ -4,6 +4,7 @@
 library;
 
 export 'account_repository.dart';
+export 'announcement_repository.dart';
 export 'appointment_document_repository.dart';
 export 'appointment_repository.dart';
 export 'base_repository.dart';
@@ -17,8 +18,10 @@ export 'consultee_profile_repository.dart';
 export 'dispute_repository.dart';
 export 'domain_repository.dart';
 export 'feedback_repository.dart';
+export 'maintenance_repository.dart';
 export 'meeting_session_repository.dart';
 export 'programs_repository.dart';
+export 'recording_repository.dart';
 export 'referral_repository.dart';
 export 'refund_repository.dart';
 export 'review_repository.dart';

--- a/backend/routes/api/announcements/index.dart
+++ b/backend/routes/api/announcements/index.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/announcements — Active announcements
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final announcements = await db.announcements.getActive();
+
+    return Response.json(
+      body: {
+        'data': announcements.map(serializeForJson).toList(),
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Announcements fetch failed',
+      context: 'AnnouncementsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load announcements'}},
+    );
+  }
+}

--- a/backend/routes/api/maintenance/status.dart
+++ b/backend/routes/api/maintenance/status.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/maintenance/status — Current maintenance status (unauthenticated)
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final db = context.read<DatabaseClient>();
+    final activeWindow = await db.maintenance.getActive();
+
+    if (activeWindow == null) {
+      return Response.json(
+        body: {
+          'maintenance': false,
+          'data': null,
+        },
+      );
+    }
+
+    return Response.json(
+      body: {
+        'maintenance': true,
+        'data': serializeForJson(activeWindow),
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Maintenance status check failed',
+      context: 'MaintenanceStatus',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    // On error, assume no maintenance (graceful degradation)
+    return Response.json(
+      body: {'maintenance': false, 'data': null},
+    );
+  }
+}

--- a/backend/routes/api/stream/recordings/[id]/index.dart
+++ b/backend/routes/api/stream/recordings/[id]/index.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// GET /api/stream/recordings/:id — Recording details
+Future<Response> onRequest(RequestContext context, String id) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final recording = await db.recordings.findById(id);
+
+    if (recording == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Recording not found'}},
+      );
+    }
+
+    return Response.json(body: {'data': recording.toJson()});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Recording get failed',
+      context: 'RecordingGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get recording'}},
+    );
+  }
+}

--- a/backend/routes/api/stream/recordings/start.dart
+++ b/backend/routes/api/stream/recordings/start.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// POST /api/stream/recordings/start — Start recording a meeting
+///
+/// Body: { "callId": "..." }
+/// This delegates to the Stream SDK to start recording.
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final callId = body['callId'] as String?;
+
+    if (callId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'error': {'message': 'callId is required'}},
+      );
+    }
+
+    // TODO: Call Stream SDK to start recording
+    // final streamService = context.read<StreamService>();
+    // await streamService.startRecording(callId);
+
+    return Response.json(
+      body: {'message': 'Recording started', 'callId': callId},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Start recording failed',
+      context: 'RecordingStart',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to start recording'}},
+    );
+  }
+}

--- a/backend/routes/api/stream/recordings/stop.dart
+++ b/backend/routes/api/stream/recordings/stop.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+/// POST /api/stream/recordings/stop — Stop recording a meeting
+///
+/// Body: { "callId": "..." }
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final callId = body['callId'] as String?;
+
+    if (callId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'error': {'message': 'callId is required'}},
+      );
+    }
+
+    // TODO: Call Stream SDK to stop recording
+    // final streamService = context.read<StreamService>();
+    // await streamService.stopRecording(callId);
+
+    return Response.json(
+      body: {'message': 'Recording stopped', 'callId': callId},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Stop recording failed',
+      context: 'RecordingStop',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to stop recording'}},
+    );
+  }
+}

--- a/backend/routes/api/support/[ticketId]/attachments.dart
+++ b/backend/routes/api/support/[ticketId]/attachments.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/support/:ticketId/attachments — List attachments
+/// POST /api/support/:ticketId/attachments — Add attachment
+///
+/// POST body:
+/// { "fileName": "...", "fileUrl": "...", "mimeType": "...",
+///   "fileSize": 123, "storagePath": "..." }
+Future<Response> onRequest(
+  RequestContext context,
+  String ticketId,
+) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) {
+    return _handleGet(context, ticketId);
+  }
+  if (method == HttpMethod.post) {
+    return _handlePost(context, ticketId);
+  }
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(
+  RequestContext context,
+  String ticketId,
+) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    // Fetch attachments via raw query (SupportTicket has no
+    // typed attachment relation in generated code)
+    final query = JsonQueryBuilder()
+        .model('SupportTicketAttachment')
+        .action(QueryAction.findMany)
+        .where({'supportTicketId': ticketId})
+        .build();
+    final attachments = await db.executor.executeQueryAsMaps(query);
+
+    return Response.json(
+      body: {
+        'data': attachments.map(serializeForJson).toList(),
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Attachment list failed',
+      context: 'SupportAttachmentsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to list attachments'}},
+    );
+  }
+}
+
+Future<Response> _handlePost(
+  RequestContext context,
+  String ticketId,
+) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final fileName = body['fileName'] as String?;
+    final fileUrl = body['fileUrl'] as String?;
+    final mimeType = body['mimeType'] as String?;
+    final fileSize = body['fileSize'] as int?;
+    final storagePath = body['storagePath'] as String?;
+
+    if (fileName == null ||
+        fileUrl == null ||
+        mimeType == null ||
+        fileSize == null ||
+        storagePath == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'fileName, fileUrl, mimeType, fileSize, '
+                'and storagePath are required',
+          },
+        },
+      );
+    }
+
+    final now = DateTime.now().toUtc().toIso8601String();
+    final db = context.read<DatabaseClient>();
+    final query = JsonQueryBuilder()
+        .model('SupportTicketAttachment')
+        .action(QueryAction.create)
+        .data({
+      'supportTicketId': ticketId,
+      'fileName': fileName,
+      'fileUrl': fileUrl,
+      'mimeType': mimeType,
+      'fileSize': fileSize,
+      'storagePath': storagePath,
+      'uploadedBy': userId,
+      'uploadedAt': now,
+    }).build();
+
+    final result = await db.executor.executeQueryAsSingleMap(query);
+
+    return Response.json(
+      statusCode: HttpStatus.created,
+      body: {'data': result != null ? serializeForJson(result) : null},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Attachment upload failed',
+      context: 'SupportAttachmentsPost',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to add attachment'}},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Four enhanced features combined into one PR (all independent, smaller scope):

### 1. Announcements (read-only on mobile)
- `AnnouncementRepository` — active announcements within date range
- `GET /api/announcements`

### 2. Maintenance Mode
- `MaintenanceRepository` — current active maintenance window
- `GET /api/maintenance/status` (unauthenticated, graceful degradation on error)

### 3. Recording Management
- `RecordingRepository` (findById, findByMeetingSession, updateMetadata)
- `POST /api/stream/recordings/start` — start recording
- `POST /api/stream/recordings/stop` — stop recording
- `GET /api/stream/recordings/:id` — recording details
- Stream SDK integration points marked with TODOs

### 4. Support Ticket Attachments
- `GET/POST /api/support/:ticketId/attachments`
- File metadata storage for support ticket files

## New Files (11)
| Type | Count | Files |
|------|-------|-------|
| Repositories | 3 | announcement, maintenance, recording |
| Routes | 6 | announcements, maintenance, recordings (3), attachments |
| Modified | 2 | database_client.dart, repositories.dart |

## Test plan
- [x] Backend tests pass (0 regressions)
- [x] `dart analyze` clean (0 errors)
- [ ] Manual test: fetch active announcements
- [ ] Manual test: check maintenance status
- [ ] Manual test: upload support attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)