### PR TITLE
feature: Phase 6+7 — content, collaborations, tax info, TDS records

### DIFF
--- a/backend/routes/api/collaborations/[id]/index.dart
+++ b/backend/routes/api/collaborations/[id]/index.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/collaborations/:id — Collaboration details with revenue split
+/// PUT /api/collaborations/:id — Update collaboration (revenue split)
+Future<Response> onRequest(RequestContext context, String id) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context, id);
+  if (method == HttpMethod.put) return _handlePut(context, id);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final query = JsonQueryBuilder()
+        .model('WebinarCollaborator')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    var collab = await db.executor.executeQueryAsSingleMap(query);
+
+    // Try class collaborator if webinar not found
+    if (collab == null) {
+      final classQuery = JsonQueryBuilder()
+          .model('ClassCollaborator')
+          .action(QueryAction.findFirst)
+          .where({'id': id})
+          .build();
+      collab = await db.executor.executeQueryAsSingleMap(classQuery);
+    }
+
+    if (collab == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Collaboration not found'}},
+      );
+    }
+
+    return Response.json(
+      body: {'data': serializeForJson(collab)},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Collaboration get failed',
+      context: 'CollaborationGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get collaboration'}},
+    );
+  }
+}
+
+Future<Response> _handlePut(RequestContext context, String id) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final revenueSplit = body['revenueSharePercentage'] as num?;
+
+    final db = context.read<DatabaseClient>();
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    // Try updating webinar collaborator first
+    final query = JsonQueryBuilder()
+        .model('WebinarCollaborator')
+        .action(QueryAction.update)
+        .where({'id': id})
+        .data({
+      if (revenueSplit != null)
+        'revenueSharePercentage': revenueSplit.toDouble(),
+      'updatedAt': now,
+    }).build();
+
+    try {
+      final result =
+          await db.executor.executeQueryAsSingleMap(query);
+      if (result != null) {
+        return Response.json(
+          body: {'data': serializeForJson(result)},
+        );
+      }
+    } catch (_) {
+      // Not a webinar collaborator, try class
+    }
+
+    // Try class collaborator
+    final classQuery = JsonQueryBuilder()
+        .model('ClassCollaborator')
+        .action(QueryAction.update)
+        .where({'id': id})
+        .data({
+      if (revenueSplit != null)
+        'revenueSharePercentage': revenueSplit.toDouble(),
+      'updatedAt': now,
+    }).build();
+
+    final result =
+        await db.executor.executeQueryAsSingleMap(classQuery);
+    if (result == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Collaboration not found'}},
+      );
+    }
+
+    return Response.json(
+      body: {'data': serializeForJson(result)},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Collaboration update failed',
+      context: 'CollaborationPut',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to update collaboration'}},
+    );
+  }
+}

--- a/backend/routes/api/consultant/tax-info/index.dart
+++ b/backend/routes/api/consultant/tax-info/index.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/consultant/tax-info — Get consultant's tax information
+/// PUT /api/consultant/tax-info — Update tax information
+Future<Response> onRequest(RequestContext context) async {
+  final method = context.request.method;
+
+  if (method == HttpMethod.get) return _handleGet(context);
+  if (method == HttpMethod.put) return _handlePut(context);
+
+  return Response(statusCode: HttpStatus.methodNotAllowed);
+}
+
+Future<Response> _handleGet(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can view tax info'},
+        },
+      );
+    }
+
+    final query = JsonQueryBuilder()
+        .model('ConsultantTaxInfo')
+        .action(QueryAction.findFirst)
+        .where({'consultantProfileId': consultantProfileId})
+        .build();
+    final taxInfo =
+        await db.executor.executeQueryAsSingleMap(query);
+
+    return Response.json(
+      body: {
+        'data': taxInfo != null ? serializeForJson(taxInfo) : null,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Tax info get failed',
+      context: 'TaxInfoGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get tax info'}},
+    );
+  }
+}
+
+Future<Response> _handlePut(RequestContext context) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'Only consultants can update tax info',
+          },
+        },
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    // Upsert tax info
+    final existingQuery = JsonQueryBuilder()
+        .model('ConsultantTaxInfo')
+        .action(QueryAction.findFirst)
+        .where({'consultantProfileId': consultantProfileId})
+        .build();
+    final existing =
+        await db.executor.executeQueryAsSingleMap(existingQuery);
+
+    if (existing != null) {
+      final updateQuery = JsonQueryBuilder()
+          .model('ConsultantTaxInfo')
+          .action(QueryAction.update)
+          .where({'id': existing['id']})
+          .data({
+        if (body.containsKey('panNumber'))
+          'panNumber': body['panNumber'],
+        if (body.containsKey('gstNumber'))
+          'gstNumber': body['gstNumber'],
+        if (body.containsKey('taxResidency'))
+          'taxResidency': body['taxResidency'],
+        'updatedAt': now,
+      }).build();
+      final result =
+          await db.executor.executeQueryAsSingleMap(updateQuery);
+      return Response.json(
+        body: {
+          'data': result != null ? serializeForJson(result) : null,
+        },
+      );
+    } else {
+      final createQuery = JsonQueryBuilder()
+          .model('ConsultantTaxInfo')
+          .action(QueryAction.create)
+          .data({
+        'consultantProfileId': consultantProfileId,
+        'panNumber': body['panNumber'],
+        'gstNumber': body['gstNumber'],
+        'taxResidency': body['taxResidency'] ?? 'IN',
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+      final result =
+          await db.executor.executeQueryAsSingleMap(createQuery);
+      return Response.json(
+        statusCode: HttpStatus.created,
+        body: {
+          'data': result != null ? serializeForJson(result) : null,
+        },
+      );
+    }
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Tax info update failed',
+      context: 'TaxInfoPut',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to update tax info'}},
+    );
+  }
+}

--- a/backend/routes/api/consultant/tds-records/index.dart
+++ b/backend/routes/api/consultant/tds-records/index.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/consultant/tds-records — List TDS deduction records
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final consultantProfileId =
+        user?['consultantProfileId'] as String?;
+    if (consultantProfileId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {'message': 'Only consultants can view TDS'},
+        },
+      );
+    }
+
+    final query = JsonQueryBuilder()
+        .model('TDSRecord')
+        .action(QueryAction.findMany)
+        .where({'consultantProfileId': consultantProfileId})
+        .build();
+    final records = await db.executor.executeQueryAsMaps(query);
+
+    return Response.json(
+      body: {'data': records.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'TDS records fetch failed',
+      context: 'TDSRecordsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load TDS records'}},
+    );
+  }
+}

--- a/backend/routes/api/domains/[id]/index.dart
+++ b/backend/routes/api/domains/[id]/index.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/domains/:id — Single domain with its subdomains
+Future<Response> onRequest(RequestContext context, String id) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final db = context.read<DatabaseClient>();
+
+    final domainQuery = JsonQueryBuilder()
+        .model('Domain')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    final domain = await db.executor.executeQueryAsSingleMap(domainQuery);
+
+    if (domain == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Domain not found'}},
+      );
+    }
+
+    final subdomainQuery = JsonQueryBuilder()
+        .model('SubDomain')
+        .action(QueryAction.findMany)
+        .where({'domainId': id})
+        .build();
+    final subdomains = await db.executor.executeQueryAsMaps(
+      subdomainQuery,
+    );
+
+    final result =
+        Map<String, dynamic>.from(serializeForJson(domain) as Map);
+    result['subdomains'] =
+        subdomains.map(serializeForJson).toList();
+
+    return Response.json(body: {'data': result});
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Domain fetch failed',
+      context: 'DomainGetById',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get domain'}},
+    );
+  }
+}

--- a/backend/routes/api/tags/index.dart
+++ b/backend/routes/api/tags/index.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/tags — List tags with optional search filter
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final search = context.request.uri.queryParameters['search'];
+    final db = context.read<DatabaseClient>();
+
+    final where = <String, dynamic>{};
+    if (search != null && search.isNotEmpty) {
+      where['name'] = {'contains': search, 'mode': 'insensitive'};
+    }
+
+    final query = JsonQueryBuilder()
+        .model('Tag')
+        .action(QueryAction.findMany)
+        .where(where)
+        .build();
+    final tags = await db.executor.executeQueryAsMaps(query);
+
+    return Response.json(
+      body: {'data': tags.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Tags fetch failed',
+      context: 'TagsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load tags'}},
+    );
+  }
+}

--- a/backend/routes/api/topics/index.dart
+++ b/backend/routes/api/topics/index.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/topics — List topics with optional search filter
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final search = context.request.uri.queryParameters['search'];
+    final db = context.read<DatabaseClient>();
+
+    final where = <String, dynamic>{};
+    if (search != null && search.isNotEmpty) {
+      where['name'] = {'contains': search, 'mode': 'insensitive'};
+    }
+
+    final query = JsonQueryBuilder()
+        .model('Topic')
+        .action(QueryAction.findMany)
+        .where(where)
+        .build();
+    final topics = await db.executor.executeQueryAsMaps(query);
+
+    return Response.json(
+      body: {'data': topics.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Topics fetch failed',
+      context: 'TopicsGet',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load topics'}},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Combined Phase 6 (Content Management + Enhanced Collaborations) and Phase 7 (Tax Info) backend routes.

### Phase 6 — Content Management
| Route | Method | Description |
|-------|--------|-------------|
| `/api/domains/:id` | GET | Domain with subdomains |
| `/api/tags` | GET | Tags with optional search |
| `/api/topics` | GET | Topics with optional search |

### Phase 6 — Enhanced Collaborations
| Route | Method | Description |
|-------|--------|-------------|
| `/api/collaborations/:id` | GET | Details + revenue split |
| `/api/collaborations/:id` | PUT | Update revenue share % |

### Phase 7 — Consultant Tax Info
| Route | Method | Description |
|-------|--------|-------------|
| `/api/consultant/tax-info` | GET/PUT | PAN, GST, residency (upsert) |
| `/api/consultant/tds-records` | GET | TDS deduction history |

## Test plan
- [x] `dart analyze` clean (0 errors)
- [ ] Manual: fetch domain with subdomains
- [ ] Manual: search tags/topics
- [ ] Manual: update collaboration revenue split
- [ ] Manual: upsert consultant tax info

🤖 Generated with [Claude Code](https://claude.com/claude-code)