### PR TITLE
feature: add remaining frontend features (Phases 4-7)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -37,6 +37,10 @@ import '../features/feedback/screens/feedback_screen.dart';
 import '../features/meetings/screens/meeting_screen.dart';
 import '../features/trials/screens/trial_list_screen.dart';
 import '../features/trials/screens/trial_request_screen.dart';
+import '../features/maintenance/screens/maintenance_screen.dart';
+import '../features/payout/screens/add_payout_account_screen.dart';
+import '../features/payout/screens/payout_accounts_screen.dart';
+import '../features/tax/screens/tax_info_screen.dart';
 import '../features/verification/screens/verification_status_screen.dart';
 import '../features/verification/screens/verification_submit_screen.dart';
 import '../features/waitlist/screens/waitlist_screen.dart';
@@ -496,6 +500,35 @@ GoRouter router(Ref ref) {
             },
           ),
         ],
+      ),
+
+      // Payout routes
+      GoRoute(
+        path: '/payout-accounts',
+        name: 'payoutAccounts',
+        builder: (context, state) => const PayoutAccountsScreen(),
+        routes: [
+          GoRoute(
+            path: 'add',
+            name: 'addPayoutAccount',
+            builder: (context, state) =>
+                const AddPayoutAccountScreen(),
+          ),
+        ],
+      ),
+
+      // Tax info routes
+      GoRoute(
+        path: '/tax-info',
+        name: 'taxInfo',
+        builder: (context, state) => const TaxInfoScreen(),
+      ),
+
+      // Maintenance route
+      GoRoute(
+        path: '/maintenance',
+        name: 'maintenance',
+        builder: (context, state) => const MaintenanceScreen(),
       ),
 
       // Support routes (PR#15)

--- a/lib/data/datasources/remote/document_remote_source.dart
+++ b/lib/data/datasources/remote/document_remote_source.dart
@@ -1,0 +1,146 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/errors/exceptions.dart';
+import '../../../domain/entities/document/document_entities.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'document_remote_source.g.dart';
+
+@riverpod
+DocumentRemoteSource documentRemoteSource(Ref ref) {
+  return DocumentRemoteSourceImpl(ref.watch(dioProvider));
+}
+
+abstract class DocumentRemoteSource {
+  Future<List<AppointmentDocument>> getDocuments(String appointmentId);
+  Future<AppointmentDocument> uploadDocument({
+    required String appointmentId,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+    String? responseToDocumentId,
+  });
+  Future<AppointmentDocument> reviewDocument({
+    required String appointmentId,
+    required String docId,
+    required String reviewStatus,
+    String? reviewNotes,
+  });
+  Future<void> deleteDocument({
+    required String appointmentId,
+    required String docId,
+  });
+}
+
+class DocumentRemoteSourceImpl implements DocumentRemoteSource {
+  final Dio _dio;
+
+  DocumentRemoteSourceImpl(this._dio);
+
+  @override
+  Future<List<AppointmentDocument>> getDocuments(
+    String appointmentId,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/api/appointments/$appointmentId/documents',
+      );
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((d) => AppointmentDocument.fromJson(
+              d as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to load documents',
+      );
+    }
+  }
+
+  @override
+  Future<AppointmentDocument> uploadDocument({
+    required String appointmentId,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+    String? responseToDocumentId,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/api/appointments/$appointmentId/documents',
+        data: {
+          'fileName': fileName,
+          'originalName': originalName,
+          'fileSize': fileSize,
+          'mimeType': mimeType,
+          'fileUrl': fileUrl,
+          'storagePath': storagePath,
+          'description': description,
+          'responseToDocumentId': responseToDocumentId,
+        },
+      );
+      return AppointmentDocument.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to upload document',
+      );
+    }
+  }
+
+  @override
+  Future<AppointmentDocument> reviewDocument({
+    required String appointmentId,
+    required String docId,
+    required String reviewStatus,
+    String? reviewNotes,
+  }) async {
+    try {
+      final response = await _dio.put(
+        '/api/appointments/$appointmentId/documents/$docId',
+        data: {
+          'reviewStatus': reviewStatus,
+          'reviewNotes': reviewNotes,
+        },
+      );
+      return AppointmentDocument.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to review document',
+      );
+    }
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String appointmentId,
+    required String docId,
+  }) async {
+    try {
+      await _dio.delete(
+        '/api/appointments/$appointmentId/documents/$docId',
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to delete document',
+      );
+    }
+  }
+}

--- a/lib/data/datasources/remote/payout_remote_source.dart
+++ b/lib/data/datasources/remote/payout_remote_source.dart
@@ -1,0 +1,113 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/errors/exceptions.dart';
+import '../../../domain/entities/payout/payout_entities.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'payout_remote_source.g.dart';
+
+@riverpod
+PayoutRemoteSource payoutRemoteSource(Ref ref) {
+  return PayoutRemoteSourceImpl(ref.watch(dioProvider));
+}
+
+abstract class PayoutRemoteSource {
+  Future<List<PayoutAccount>> getAccounts();
+  Future<PayoutAccount> createAccount(Map<String, dynamic> data);
+  Future<PayoutAccount> updateAccount(String id, Map<String, dynamic> data);
+  Future<void> deleteAccount(String id);
+  Future<void> setDefault(String id);
+}
+
+class PayoutRemoteSourceImpl implements PayoutRemoteSource {
+  final Dio _dio;
+  PayoutRemoteSourceImpl(this._dio);
+
+  @override
+  Future<List<PayoutAccount>> getAccounts() async {
+    try {
+      final response = await _dio.get(
+        '/api/consultant/payout-accounts',
+      );
+      final data = response.data['data'] as List<dynamic>;
+      return data
+          .map((d) =>
+              PayoutAccount.fromJson(d as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to load accounts',
+      );
+    }
+  }
+
+  @override
+  Future<PayoutAccount> createAccount(
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _dio.post(
+        '/api/consultant/payout-accounts',
+        data: data,
+      );
+      return PayoutAccount.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to create account',
+      );
+    }
+  }
+
+  @override
+  Future<PayoutAccount> updateAccount(
+    String id,
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _dio.put(
+        '/api/consultant/payout-accounts/$id',
+        data: data,
+      );
+      return PayoutAccount.fromJson(
+        response.data['data'] as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to update account',
+      );
+    }
+  }
+
+  @override
+  Future<void> deleteAccount(String id) async {
+    try {
+      await _dio.delete('/api/consultant/payout-accounts/$id');
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to delete account',
+      );
+    }
+  }
+
+  @override
+  Future<void> setDefault(String id) async {
+    try {
+      await _dio.post(
+        '/api/consultant/payout-accounts/$id/set-default',
+      );
+    } on DioException catch (e) {
+      throw ServerException(
+        message: e.response?.data?['error']?['message'] ??
+            'Failed to set default',
+      );
+    }
+  }
+}

--- a/lib/domain/entities/announcement/announcement_entity.dart
+++ b/lib/domain/entities/announcement/announcement_entity.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'announcement_entity.freezed.dart';
+part 'announcement_entity.g.dart';
+
+@freezed
+class Announcement with _$Announcement {
+  const factory Announcement({
+    required String id,
+    required String title,
+    String? message,
+    String? type,
+    String? linkUrl,
+    String? linkText,
+    String? backgroundColor,
+    String? textColor,
+    @Default(true) bool isActive,
+    DateTime? startDate,
+    DateTime? endDate,
+    required DateTime createdAt,
+  }) = _Announcement;
+
+  factory Announcement.fromJson(Map<String, dynamic> json) =>
+      _$AnnouncementFromJson(json);
+}

--- a/lib/domain/entities/document/appointment_document.dart
+++ b/lib/domain/entities/document/appointment_document.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'document_review_status.dart';
+
+part 'appointment_document.freezed.dart';
+part 'appointment_document.g.dart';
+
+@freezed
+class AppointmentDocument with _$AppointmentDocument {
+  const factory AppointmentDocument({
+    required String id,
+    required String fileName,
+    required String originalName,
+    required int fileSize,
+    required String mimeType,
+    required String fileUrl,
+    required String storagePath,
+    String? description,
+    required DocumentReviewStatus reviewStatus,
+    String? reviewNotes,
+    DateTime? reviewedAt,
+    String? reviewedBy,
+    required String uploadedByRole,
+    String? responseToDocumentId,
+    required String appointmentId,
+    required DateTime uploadedAt,
+    required DateTime updatedAt,
+  }) = _AppointmentDocument;
+
+  factory AppointmentDocument.fromJson(Map<String, dynamic> json) =>
+      _$AppointmentDocumentFromJson(json);
+}

--- a/lib/domain/entities/document/document_entities.dart
+++ b/lib/domain/entities/document/document_entities.dart
@@ -1,0 +1,5 @@
+/// Document review domain entities
+library;
+
+export 'appointment_document.dart';
+export 'document_review_status.dart';

--- a/lib/domain/entities/document/document_review_status.dart
+++ b/lib/domain/entities/document/document_review_status.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+enum DocumentReviewStatus {
+  @JsonValue('PENDING')
+  pending,
+  @JsonValue('IN_REVIEW')
+  inReview,
+  @JsonValue('APPROVED')
+  approved,
+  @JsonValue('REJECTED')
+  rejected,
+  @JsonValue('NEEDS_REVISION')
+  needsRevision,
+}
+
+extension DocumentReviewStatusX on DocumentReviewStatus {
+  String get displayLabel => switch (this) {
+        DocumentReviewStatus.pending => 'Pending',
+        DocumentReviewStatus.inReview => 'In Review',
+        DocumentReviewStatus.approved => 'Approved',
+        DocumentReviewStatus.rejected => 'Rejected',
+        DocumentReviewStatus.needsRevision => 'Needs Revision',
+      };
+
+  bool get isPending => this == DocumentReviewStatus.pending;
+}

--- a/lib/domain/entities/payout/payout_account.dart
+++ b/lib/domain/entities/payout/payout_account.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payout_account.freezed.dart';
+part 'payout_account.g.dart';
+
+@freezed
+class PayoutAccount with _$PayoutAccount {
+  const factory PayoutAccount({
+    required String id,
+    required String consultantProfileId,
+    required String provider,
+    required String accountType,
+    String? accountHolderName,
+    String? bankName,
+    String? accountNumberLast4,
+    String? ifscCode,
+    String? upiId,
+    @Default(false) bool isVerified,
+    @Default(false) bool isDefault,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _PayoutAccount;
+
+  factory PayoutAccount.fromJson(Map<String, dynamic> json) =>
+      _$PayoutAccountFromJson(json);
+}

--- a/lib/domain/entities/payout/payout_entities.dart
+++ b/lib/domain/entities/payout/payout_entities.dart
@@ -1,0 +1,4 @@
+/// Payout domain entities
+library;
+
+export 'payout_account.dart';

--- a/lib/domain/entities/tax/tax_entities.dart
+++ b/lib/domain/entities/tax/tax_entities.dart
@@ -1,0 +1,39 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'tax_entities.freezed.dart';
+part 'tax_entities.g.dart';
+
+@freezed
+class ConsultantTaxInfo with _$ConsultantTaxInfo {
+  const factory ConsultantTaxInfo({
+    required String id,
+    required String consultantProfileId,
+    String? panNumber,
+    String? gstNumber,
+    String? taxResidency,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _ConsultantTaxInfo;
+
+  factory ConsultantTaxInfo.fromJson(Map<String, dynamic> json) =>
+      _$ConsultantTaxInfoFromJson(json);
+}
+
+@freezed
+class TDSRecord with _$TDSRecord {
+  const factory TDSRecord({
+    required String id,
+    required String consultantProfileId,
+    String? financialYear,
+    String? quarter,
+    double? tdsAmount,
+    double? grossAmount,
+    double? tdsPercentage,
+    String? status,
+    DateTime? deductedAt,
+    required DateTime createdAt,
+  }) = _TDSRecord;
+
+  factory TDSRecord.fromJson(Map<String, dynamic> json) =>
+      _$TDSRecordFromJson(json);
+}

--- a/lib/features/announcements/providers/announcement_provider.dart
+++ b/lib/features/announcements/providers/announcement_provider.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../domain/entities/announcement/announcement_entity.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'announcement_provider.g.dart';
+
+@riverpod
+Future<List<Announcement>> announcements(AnnouncementsRef ref) async {
+  final dio = ref.watch(dioProvider);
+  final response = await dio.get('/api/announcements');
+  final data = response.data['data'] as List<dynamic>;
+  return data
+      .map((d) => Announcement.fromJson(d as Map<String, dynamic>))
+      .toList();
+}

--- a/lib/features/announcements/widgets/announcement_banner.dart
+++ b/lib/features/announcements/widgets/announcement_banner.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../providers/announcement_provider.dart';
+
+/// Dismissible announcement banner shown at the top of the main shell.
+class AnnouncementBanner extends ConsumerStatefulWidget {
+  const AnnouncementBanner({super.key});
+
+  @override
+  ConsumerState<AnnouncementBanner> createState() =>
+      _AnnouncementBannerState();
+}
+
+class _AnnouncementBannerState
+    extends ConsumerState<AnnouncementBanner> {
+  final _dismissed = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final announcementsAsync = ref.watch(announcementsProvider);
+
+    return announcementsAsync.when(
+      data: (announcements) {
+        final visible = announcements
+            .where((a) => !_dismissed.contains(a.id))
+            .toList();
+        if (visible.isEmpty) return const SizedBox.shrink();
+
+        final announcement = visible.first;
+        final bgColor = announcement.backgroundColor != null
+            ? Color(
+                int.parse(
+                      announcement.backgroundColor!.replaceFirst(
+                        '#',
+                        '',
+                      ),
+                      radix: 16,
+                    ) |
+                    0xFF000000,
+              )
+            : Theme.of(context).colorScheme.primaryContainer;
+
+        return MaterialBanner(
+          content: Text(
+            announcement.message ?? announcement.title,
+            style: TextStyle(
+              color: announcement.textColor != null
+                  ? Color(
+                      int.parse(
+                            announcement.textColor!.replaceFirst(
+                              '#',
+                              '',
+                            ),
+                            radix: 16,
+                          ) |
+                          0xFF000000,
+                    )
+                  : null,
+            ),
+          ),
+          backgroundColor: bgColor,
+          actions: [
+            if (announcement.linkUrl != null)
+              TextButton(
+                onPressed: () =>
+                    launchUrl(Uri.parse(announcement.linkUrl!)),
+                child: Text(announcement.linkText ?? 'Learn more'),
+              ),
+            IconButton(
+              icon: const Icon(Icons.close, size: 18),
+              onPressed: () =>
+                  setState(() => _dismissed.add(announcement.id)),
+            ),
+          ],
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/features/maintenance/providers/maintenance_provider.dart
+++ b/lib/features/maintenance/providers/maintenance_provider.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../shared/providers/core_providers.dart';
+
+part 'maintenance_provider.g.dart';
+
+@riverpod
+Future<bool> maintenanceStatus(MaintenanceStatusRef ref) async {
+  try {
+    final dio = ref.watch(dioProvider);
+    final response = await dio.get('/api/maintenance/status');
+    return response.data['maintenance'] as bool? ?? false;
+  } catch (_) {
+    // On error, assume no maintenance (graceful degradation)
+    return false;
+  }
+}

--- a/lib/features/maintenance/screens/maintenance_screen.dart
+++ b/lib/features/maintenance/screens/maintenance_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class MaintenanceScreen extends StatelessWidget {
+  const MaintenanceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.engineering,
+                size: 80,
+                color: Colors.orange,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Under Maintenance',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'We are performing scheduled maintenance. '
+                'Please try again shortly.',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/payout/providers/payout_provider.dart
+++ b/lib/features/payout/providers/payout_provider.dart
@@ -1,0 +1,71 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../../../data/datasources/remote/payout_remote_source.dart';
+import '../../../domain/entities/payout/payout_entities.dart';
+
+part 'payout_provider.g.dart';
+
+@riverpod
+class PayoutAccounts extends _$PayoutAccounts {
+  @override
+  Future<List<PayoutAccount>> build() async {
+    final source = ref.read(payoutRemoteSourceProvider);
+    return source.getAccounts();
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    try {
+      final source = ref.read(payoutRemoteSourceProvider);
+      state = AsyncData(await source.getAccounts());
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'PayoutAccounts.refresh');
+      state = AsyncError(e, stack);
+    }
+  }
+
+  Future<void> create(Map<String, dynamic> data) async {
+    try {
+      final source = ref.read(payoutRemoteSourceProvider);
+      final account = await source.createAccount(data);
+      final current = state.valueOrNull ?? [];
+      state = AsyncData([...current, account]);
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'PayoutAccounts.create');
+      rethrow;
+    }
+  }
+
+  Future<void> delete(String id) async {
+    try {
+      final source = ref.read(payoutRemoteSourceProvider);
+      await source.deleteAccount(id);
+      final current = state.valueOrNull ?? [];
+      state = AsyncData(current.where((a) => a.id != id).toList());
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'PayoutAccounts.delete');
+      rethrow;
+    }
+  }
+
+  Future<void> setDefault(String id) async {
+    try {
+      final source = ref.read(payoutRemoteSourceProvider);
+      await source.setDefault(id);
+      final current = state.valueOrNull ?? [];
+      state = AsyncData(
+        current
+            .map((a) => a.copyWith(isDefault: a.id == id))
+            .toList(),
+      );
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'PayoutAccounts.setDefault');
+      rethrow;
+    }
+  }
+}

--- a/lib/features/payout/screens/add_payout_account_screen.dart
+++ b/lib/features/payout/screens/add_payout_account_screen.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../providers/payout_provider.dart';
+
+class AddPayoutAccountScreen extends ConsumerStatefulWidget {
+  const AddPayoutAccountScreen({super.key});
+
+  @override
+  ConsumerState<AddPayoutAccountScreen> createState() =>
+      _AddPayoutAccountScreenState();
+}
+
+class _AddPayoutAccountScreenState
+    extends ConsumerState<AddPayoutAccountScreen> {
+  String _accountType = 'BANK_ACCOUNT';
+  final _holderNameCtrl = TextEditingController();
+  final _bankNameCtrl = TextEditingController();
+  final _last4Ctrl = TextEditingController();
+  final _ifscCtrl = TextEditingController();
+  final _upiCtrl = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _holderNameCtrl.dispose();
+    _bankNameCtrl.dispose();
+    _last4Ctrl.dispose();
+    _ifscCtrl.dispose();
+    _upiCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Payout Account')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(
+                  value: 'BANK_ACCOUNT',
+                  label: Text('Bank'),
+                  icon: Icon(Icons.account_balance),
+                ),
+                ButtonSegment(
+                  value: 'UPI',
+                  label: Text('UPI'),
+                  icon: Icon(Icons.phone_android),
+                ),
+              ],
+              selected: {_accountType},
+              onSelectionChanged: (v) =>
+                  setState(() => _accountType = v.first),
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _holderNameCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Account Holder Name',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (_accountType == 'BANK_ACCOUNT') ...[
+              TextField(
+                controller: _bankNameCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Bank Name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _last4Ctrl,
+                decoration: const InputDecoration(
+                  labelText: 'Last 4 digits of account number',
+                  border: OutlineInputBorder(),
+                ),
+                maxLength: 4,
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _ifscCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'IFSC Code',
+                  border: OutlineInputBorder(),
+                ),
+                textCapitalization: TextCapitalization.characters,
+              ),
+            ] else ...[
+              TextField(
+                controller: _upiCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'UPI ID (e.g., name@upi)',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isSubmitting ? null : _submit,
+                child: _isSubmitting
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : const Text('Add Account'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _isSubmitting = true);
+    try {
+      await ref.read(payoutAccountsProvider.notifier).create({
+        'provider': 'RAZORPAY',
+        'accountType': _accountType,
+        'accountHolderName': _holderNameCtrl.text.isEmpty
+            ? null
+            : _holderNameCtrl.text,
+        if (_accountType == 'BANK_ACCOUNT') ...{
+          'bankName': _bankNameCtrl.text.isEmpty
+              ? null
+              : _bankNameCtrl.text,
+          'accountNumberLast4': _last4Ctrl.text.isEmpty
+              ? null
+              : _last4Ctrl.text,
+          'ifscCode':
+              _ifscCtrl.text.isEmpty ? null : _ifscCtrl.text,
+        } else ...{
+          'upiId': _upiCtrl.text.isEmpty ? null : _upiCtrl.text,
+        },
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Account added')),
+        );
+        context.pop();
+      }
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'AddPayoutAccount._submit');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to add account. Please try again.'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+}

--- a/lib/features/payout/screens/payout_accounts_screen.dart
+++ b/lib/features/payout/screens/payout_accounts_screen.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../domain/entities/payout/payout_entities.dart';
+import '../providers/payout_provider.dart';
+
+class PayoutAccountsScreen extends ConsumerWidget {
+  const PayoutAccountsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accountsAsync = ref.watch(payoutAccountsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payout Accounts')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.push('/payout-accounts/add'),
+        child: const Icon(Icons.add),
+      ),
+      body: accountsAsync.when(
+        data: (accounts) {
+          if (accounts.isEmpty) {
+            return const Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.account_balance, size: 64, color: Colors.grey),
+                  SizedBox(height: 16),
+                  Text('No payout accounts yet'),
+                  SizedBox(height: 8),
+                  Text('Add a bank account or UPI to receive payouts'),
+                ],
+              ),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: () =>
+                ref.read(payoutAccountsProvider.notifier).refresh(),
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: accounts.length,
+              itemBuilder: (context, index) => _AccountCard(
+                account: accounts[index],
+                onSetDefault: () => _setDefault(
+                  ref, context, accounts[index].id,
+                ),
+                onDelete: () => _delete(
+                  ref, context, accounts[index].id,
+                ),
+              ),
+            ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Error: $e'),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () =>
+                    ref.read(payoutAccountsProvider.notifier).refresh(),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _setDefault(
+    WidgetRef ref, BuildContext context, String id,
+  ) async {
+    try {
+      await ref.read(payoutAccountsProvider.notifier).setDefault(id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Default account updated')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to update. Please try again.'),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _delete(
+    WidgetRef ref, BuildContext context, String id,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Account'),
+        content: const Text('Are you sure?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await ref.read(payoutAccountsProvider.notifier).delete(id);
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to delete. Please try again.'),
+          ),
+        );
+      }
+    }
+  }
+}
+
+class _AccountCard extends StatelessWidget {
+  const _AccountCard({
+    required this.account,
+    this.onSetDefault,
+    this.onDelete,
+  });
+
+  final PayoutAccount account;
+  final VoidCallback? onSetDefault;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  account.accountType == 'UPI'
+                      ? Icons.phone_android
+                      : Icons.account_balance,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  account.accountType == 'UPI'
+                      ? 'UPI'
+                      : account.bankName ?? 'Bank Account',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const Spacer(),
+                if (account.isDefault)
+                  Chip(
+                    label: const Text('Default',
+                        style: TextStyle(fontSize: 11)),
+                    backgroundColor:
+                        Colors.green.withValues(alpha: 0.1),
+                    side: BorderSide.none,
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (account.accountHolderName != null)
+              Text(account.accountHolderName!),
+            if (account.accountNumberLast4 != null)
+              Text('****${account.accountNumberLast4}'),
+            if (account.upiId != null)
+              Text(account.upiId!),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (!account.isDefault)
+                  TextButton(
+                    onPressed: onSetDefault,
+                    child: const Text('Set Default'),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, size: 20),
+                  onPressed: onDelete,
+                  color: Colors.red,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/tax/providers/tax_provider.dart
+++ b/lib/features/tax/providers/tax_provider.dart
@@ -1,0 +1,55 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../../../domain/entities/tax/tax_entities.dart';
+import '../../../shared/providers/core_providers.dart';
+
+part 'tax_provider.g.dart';
+
+@riverpod
+class TaxInfoState extends _$TaxInfoState {
+  @override
+  Future<ConsultantTaxInfo?> build() async {
+    final dio = ref.read(dioProvider);
+    final response = await dio.get('/api/consultant/tax-info');
+    final data = response.data['data'];
+    if (data == null) return null;
+    return ConsultantTaxInfo.fromJson(
+      data as Map<String, dynamic>,
+    );
+  }
+
+  Future<void> save(Map<String, dynamic> data) async {
+    state = const AsyncLoading();
+    try {
+      final dio = ref.read(dioProvider);
+      final response = await dio.put(
+        '/api/consultant/tax-info',
+        data: data,
+      );
+      final result = response.data['data'];
+      if (result != null) {
+        state = AsyncData(
+          ConsultantTaxInfo.fromJson(
+            result as Map<String, dynamic>,
+          ),
+        );
+      }
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'TaxInfoState.update');
+      state = AsyncError(e, stack);
+    }
+  }
+}
+
+@riverpod
+Future<List<TDSRecord>> tdsRecords(TdsRecordsRef ref) async {
+  final dio = ref.watch(dioProvider);
+  final response = await dio.get('/api/consultant/tds-records');
+  final data = response.data['data'] as List<dynamic>;
+  return data
+      .map((d) => TDSRecord.fromJson(d as Map<String, dynamic>))
+      .toList();
+}

--- a/lib/features/tax/screens/tax_info_screen.dart
+++ b/lib/features/tax/screens/tax_info_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/utils/sentry_logger.dart';
+import '../providers/tax_provider.dart';
+
+class TaxInfoScreen extends ConsumerStatefulWidget {
+  const TaxInfoScreen({super.key});
+
+  @override
+  ConsumerState<TaxInfoScreen> createState() => _TaxInfoScreenState();
+}
+
+class _TaxInfoScreenState extends ConsumerState<TaxInfoScreen> {
+  final _panCtrl = TextEditingController();
+  final _gstCtrl = TextEditingController();
+  bool _isSubmitting = false;
+  bool _initialized = false;
+
+  @override
+  void dispose() {
+    _panCtrl.dispose();
+    _gstCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final taxInfoAsync = ref.watch(taxInfoStateProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tax Information')),
+      body: taxInfoAsync.when(
+        data: (taxInfo) {
+          if (!_initialized && taxInfo != null) {
+            _panCtrl.text = taxInfo.panNumber ?? '';
+            _gstCtrl.text = taxInfo.gstNumber ?? '';
+            _initialized = true;
+          }
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Tax Details',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Required for TDS compliance and generating '
+                  'tax invoices.',
+                ),
+                const SizedBox(height: 24),
+                TextField(
+                  controller: _panCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'PAN Number',
+                    hintText: 'ABCDE1234F',
+                    border: OutlineInputBorder(),
+                  ),
+                  textCapitalization: TextCapitalization.characters,
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _gstCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'GST Number (optional)',
+                    hintText: '22AAAAA0000A1Z5',
+                    border: OutlineInputBorder(),
+                  ),
+                  textCapitalization: TextCapitalization.characters,
+                ),
+                const SizedBox(height: 32),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: _isSubmitting ? null : _save,
+                    child: _isSubmitting
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
+                        : const Text('Save Tax Info'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        loading: () =>
+            const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    setState(() => _isSubmitting = true);
+    try {
+      await ref.read(taxInfoStateProvider.notifier).save({
+        'panNumber':
+            _panCtrl.text.isEmpty ? null : _panCtrl.text,
+        'gstNumber':
+            _gstCtrl.text.isEmpty ? null : _gstCtrl.text,
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Tax info saved')),
+        );
+      }
+    } catch (e, stack) {
+      AppSentryLogger.captureException(e,
+          stackTrace: stack, context: 'TaxInfoScreen._save');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to save. Please try again.'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
All remaining frontend features for Phases 4-7 (19 new files, 1245 lines):

### Phase 4 — Document Review + Payout Accounts
- `AppointmentDocument` entity + `DocumentReviewStatus` enum + `DocumentRemoteSource`
- `PayoutAccount` entity + `PayoutRemoteSource` + `PayoutAccounts` provider
- `PayoutAccountsScreen` (list/set-default/delete) + `AddPayoutAccountScreen` (bank/UPI form)

### Phase 5 — Announcements + Maintenance
- `Announcement` entity + provider + `AnnouncementBanner` (dismissible MaterialBanner)
- `maintenanceStatus` provider (graceful degradation) + `MaintenanceScreen`

### Phase 7 — Tax Info
- `ConsultantTaxInfo` + `TDSRecord` entities + providers
- `TaxInfoScreen` (PAN/GST form with upsert)

### Routes Added
- `/payout-accounts`, `/payout-accounts/add`
- `/tax-info`
- `/maintenance`

## Test plan
- [x] `dart analyze` clean (0 errors)
- [x] Build runner generates all code (33 outputs)
- [ ] Manual: payout account CRUD flow
- [ ] Manual: view/dismiss announcement banner
- [ ] Manual: tax info save flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)