### PR TITLE
fix: security audit — authorization + input validation

### DIFF
--- a/backend/routes/api/collaborations/[id]/index.dart
+++ b/backend/routes/api/collaborations/[id]/index.dart
@@ -18,6 +18,68 @@ Future<Response> onRequest(RequestContext context, String id) async {
   return Response(statusCode: HttpStatus.methodNotAllowed);
 }
 
+/// Find a collaboration and verify the user is a participant.
+/// Returns the collaboration data or a Response to return early.
+Future<Object> _findAndAuthorize(
+  RequestContext context,
+  String id,
+  String userId,
+) async {
+  final db = context.read<DatabaseClient>();
+
+  // Get user's consultant profile ID
+  final user = await db.users.findById(userId);
+  final consultantProfileId =
+      user?['consultantProfileId'] as String?;
+  if (consultantProfileId == null) {
+    return Response.json(
+      statusCode: HttpStatus.forbidden,
+      body: {
+        'error': {
+          'message': 'Only consultants can access collaborations',
+        },
+      },
+    );
+  }
+
+  // Try webinar collaborator
+  final webQuery = JsonQueryBuilder()
+      .model('WebinarCollaborator')
+      .action(QueryAction.findFirst)
+      .where({'id': id})
+      .build();
+  var collab = await db.executor.executeQueryAsSingleMap(webQuery);
+
+  // Try class collaborator if not found
+  if (collab == null) {
+    final classQuery = JsonQueryBuilder()
+        .model('ClassCollaborator')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    collab = await db.executor.executeQueryAsSingleMap(classQuery);
+  }
+
+  if (collab == null) {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'error': {'message': 'Collaboration not found'}},
+    );
+  }
+
+  // Verify the user is a participant in this collaboration
+  final collabProfileId =
+      collab['consultantProfileId'] as String?;
+  if (collabProfileId != consultantProfileId) {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'error': {'message': 'Collaboration not found'}},
+    );
+  }
+
+  return collab;
+}
+
 Future<Response> _handleGet(RequestContext context, String id) async {
   try {
     final userId = getUserIdFromToken(context);
@@ -28,33 +90,15 @@ Future<Response> _handleGet(RequestContext context, String id) async {
       );
     }
 
-    final db = context.read<DatabaseClient>();
-    final query = JsonQueryBuilder()
-        .model('WebinarCollaborator')
-        .action(QueryAction.findFirst)
-        .where({'id': id})
-        .build();
-    var collab = await db.executor.executeQueryAsSingleMap(query);
-
-    // Try class collaborator if webinar not found
-    if (collab == null) {
-      final classQuery = JsonQueryBuilder()
-          .model('ClassCollaborator')
-          .action(QueryAction.findFirst)
-          .where({'id': id})
-          .build();
-      collab = await db.executor.executeQueryAsSingleMap(classQuery);
-    }
-
-    if (collab == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Collaboration not found'}},
-      );
-    }
+    final result = await _findAndAuthorize(context, id, userId);
+    if (result is Response) return result;
 
     return Response.json(
-      body: {'data': serializeForJson(collab)},
+      body: {
+        'data': serializeForJson(
+          result as Map<String, dynamic>,
+        ),
+      },
     );
   } catch (e, stackTrace) {
     await SentryLogger.severe(
@@ -80,15 +124,23 @@ Future<Response> _handlePut(RequestContext context, String id) async {
       );
     }
 
+    // Authorize first
+    final authResult = await _findAndAuthorize(context, id, userId);
+    if (authResult is Response) return authResult;
+    final collab = authResult as Map<String, dynamic>;
+
     final body = await context.request.json() as Map<String, dynamic>;
     final revenueSplit = body['revenueSharePercentage'] as num?;
-
     final db = context.read<DatabaseClient>();
     final now = DateTime.now().toUtc().toIso8601String();
 
-    // Try updating webinar collaborator first
-    final query = JsonQueryBuilder()
-        .model('WebinarCollaborator')
+    // Determine which model to update based on what we found
+    final modelName = collab.containsKey('webinarPlanId')
+        ? 'WebinarCollaborator'
+        : 'ClassCollaborator';
+
+    final updateQuery = JsonQueryBuilder()
+        .model(modelName)
         .action(QueryAction.update)
         .where({'id': id})
         .data({
@@ -97,40 +149,14 @@ Future<Response> _handlePut(RequestContext context, String id) async {
       'updatedAt': now,
     }).build();
 
-    try {
-      final result =
-          await db.executor.executeQueryAsSingleMap(query);
-      if (result != null) {
-        return Response.json(
-          body: {'data': serializeForJson(result)},
-        );
-      }
-    } catch (_) {
-      // Not a webinar collaborator, try class
-    }
-
-    // Try class collaborator
-    final classQuery = JsonQueryBuilder()
-        .model('ClassCollaborator')
-        .action(QueryAction.update)
-        .where({'id': id})
-        .data({
-      if (revenueSplit != null)
-        'revenueSharePercentage': revenueSplit.toDouble(),
-      'updatedAt': now,
-    }).build();
-
-    final result =
-        await db.executor.executeQueryAsSingleMap(classQuery);
-    if (result == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Collaboration not found'}},
-      );
-    }
+    final updated =
+        await db.executor.executeQueryAsSingleMap(updateQuery);
 
     return Response.json(
-      body: {'data': serializeForJson(result)},
+      body: {
+        'data':
+            updated != null ? serializeForJson(updated) : null,
+      },
     );
   } catch (e, stackTrace) {
     await SentryLogger.severe(

--- a/backend/routes/api/consultant/tax-info/index.dart
+++ b/backend/routes/api/consultant/tax-info/index.dart
@@ -127,14 +127,27 @@ Future<Response> _handlePut(RequestContext context) async {
         },
       );
     } else {
+      // Validate required fields for creation
+      final panNumber = body['panNumber'] as String?;
+      if (panNumber == null || panNumber.isEmpty) {
+        return Response.json(
+          statusCode: HttpStatus.badRequest,
+          body: {
+            'error': {
+              'message': 'panNumber is required for new tax info',
+            },
+          },
+        );
+      }
+
       final createQuery = JsonQueryBuilder()
           .model('ConsultantTaxInfo')
           .action(QueryAction.create)
           .data({
         'consultantProfileId': consultantProfileId,
-        'panNumber': body['panNumber'],
-        'gstNumber': body['gstNumber'],
-        'taxResidency': body['taxResidency'] ?? 'IN',
+        'panNumber': panNumber,
+        'gstNumber': body['gstNumber'] as String?,
+        'taxResidency': body['taxResidency'] as String? ?? 'IN',
         'createdAt': now,
         'updatedAt': now,
       }).build();

--- a/backend/routes/api/staff/moderation/profiles/[verificationId]/index.dart
+++ b/backend/routes/api/staff/moderation/profiles/[verificationId]/index.dart
@@ -40,6 +40,17 @@ Future<Response> _handleGet(
     }
 
     final db = context.read<DatabaseClient>();
+
+    // Verify staff role
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    if (role != 'STAFF' && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Staff access required'}},
+      );
+    }
+
     final verification =
         await db.consultantVerifications.findById(verificationId);
 


### PR DESCRIPTION
## Summary
Fixes for legitimate security issues identified by Gemini Code Assist reviews on PRs #75 and #77 that were merged before fixes were applied.

### CRITICAL: Collaboration routes missing authorization
- `GET/PUT /api/collaborations/:id` had no ownership check — **any authenticated user could view or modify any collaboration's revenue split**
- Added `_findAndAuthorize()` that verifies user's `consultantProfileId` matches the collaboration
- Also fixed silent `catch (_)` that swallowed all exceptions

### HIGH: Staff verification GET missing role check
- `GET /api/staff/moderation/profiles/:id` checked authentication but not role — **any authenticated user could read verification details**
- Added STAFF/ADMIN role verification (was already on PUT, missing on GET)

### HIGH: Tax info missing input validation
- `PUT /api/consultant/tax-info` create path accepted null `panNumber`, causing a 500 instead of 400
- Added explicit validation with user-friendly error message

## Files Changed
| File | Fix |
|------|-----|
| `backend/routes/api/collaborations/[id]/index.dart` | Authorization + error handling |
| `backend/routes/api/staff/moderation/profiles/[verificationId]/index.dart` | Role check on GET |
| `backend/routes/api/consultant/tax-info/index.dart` | Input validation |

## Test plan
- [x] Backend tests pass (0 regressions)
- [x] `dart analyze` clean
- [ ] Manual: verify non-participant cannot access collaborations
- [ ] Manual: verify non-staff cannot access verification GET

🤖 Generated with [Claude Code](https://claude.com/claude-code)