### PR TITLE
feature: integrate Stream Video recording API

### DIFF
--- a/backend/lib/services/stream_service.dart
+++ b/backend/lib/services/stream_service.dart
@@ -493,44 +493,20 @@ class StreamService {
   static const _videoApiBaseUrl = 'https://video.stream-io-api.com';
 
   /// Start recording a call.
-  ///
-  /// See: https://getstream.io/video/docs/api/recording/start/
   Future<void> startRecording(String callId) async {
-    if (!isConfigured) {
-      throw StateError('Stream API key and secret must be configured');
-    }
-
-    final serverToken = _createServerToken();
-    final response = await http.post(
-      Uri.parse(
-        '$_videoApiBaseUrl/api/v2/video/call/default/$callId'
-        '/start_recording',
-      ),
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': serverToken,
-        'Stream-Auth-Type': 'jwt',
-        'api_key': _apiKey,
-      },
-      body: jsonEncode({}),
-    );
-
-    if (response.statusCode != 201 && response.statusCode != 200) {
-      final body = response.body;
-      SentryLogger.info(
-        'Stream start recording error: $body',
-        context: 'StreamService.startRecording',
-      );
-      throw Exception(
-        'Failed to start recording: ${response.statusCode}',
-      );
-    }
+    await _postRecordingAction(callId, 'start_recording');
   }
 
   /// Stop recording a call.
-  ///
-  /// See: https://getstream.io/video/docs/api/recording/stop/
   Future<void> stopRecording(String callId) async {
+    await _postRecordingAction(callId, 'stop_recording');
+  }
+
+  /// Shared helper for start/stop recording API calls.
+  Future<void> _postRecordingAction(
+    String callId,
+    String action,
+  ) async {
     if (!isConfigured) {
       throw StateError('Stream API key and secret must be configured');
     }
@@ -539,7 +515,7 @@ class StreamService {
     final response = await http.post(
       Uri.parse(
         '$_videoApiBaseUrl/api/v2/video/call/default/$callId'
-        '/stop_recording',
+        '/$action',
       ),
       headers: {
         'Content-Type': 'application/json',
@@ -553,11 +529,11 @@ class StreamService {
     if (response.statusCode != 201 && response.statusCode != 200) {
       final body = response.body;
       SentryLogger.info(
-        'Stream stop recording error: $body',
-        context: 'StreamService.stopRecording',
+        'Stream $action error: $body',
+        context: 'StreamService.$action',
       );
       throw Exception(
-        'Failed to stop recording: ${response.statusCode}',
+        'Failed to $action: ${response.statusCode}',
       );
     }
   }
@@ -586,6 +562,11 @@ class StreamService {
     );
 
     if (response.statusCode != 200) {
+      final body = response.body;
+      SentryLogger.info(
+        'Stream list recordings error: $body',
+        context: 'StreamService.listRecordings',
+      );
       throw Exception(
         'Failed to list recordings: ${response.statusCode}',
       );

--- a/backend/lib/services/stream_service.dart
+++ b/backend/lib/services/stream_service.dart
@@ -484,6 +484,117 @@ class StreamService {
       rethrow;
     }
   }
+
+  // ===========================================================================
+  // Video Recording API
+  // ===========================================================================
+
+  /// Stream Video API base URL
+  static const _videoApiBaseUrl = 'https://video.stream-io-api.com';
+
+  /// Start recording a call.
+  ///
+  /// See: https://getstream.io/video/docs/api/recording/start/
+  Future<void> startRecording(String callId) async {
+    if (!isConfigured) {
+      throw StateError('Stream API key and secret must be configured');
+    }
+
+    final serverToken = _createServerToken();
+    final response = await http.post(
+      Uri.parse(
+        '$_videoApiBaseUrl/api/v2/video/call/default/$callId'
+        '/start_recording',
+      ),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': serverToken,
+        'Stream-Auth-Type': 'jwt',
+        'api_key': _apiKey,
+      },
+      body: jsonEncode({}),
+    );
+
+    if (response.statusCode != 201 && response.statusCode != 200) {
+      final body = response.body;
+      SentryLogger.info(
+        'Stream start recording error: $body',
+        context: 'StreamService.startRecording',
+      );
+      throw Exception(
+        'Failed to start recording: ${response.statusCode}',
+      );
+    }
+  }
+
+  /// Stop recording a call.
+  ///
+  /// See: https://getstream.io/video/docs/api/recording/stop/
+  Future<void> stopRecording(String callId) async {
+    if (!isConfigured) {
+      throw StateError('Stream API key and secret must be configured');
+    }
+
+    final serverToken = _createServerToken();
+    final response = await http.post(
+      Uri.parse(
+        '$_videoApiBaseUrl/api/v2/video/call/default/$callId'
+        '/stop_recording',
+      ),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': serverToken,
+        'Stream-Auth-Type': 'jwt',
+        'api_key': _apiKey,
+      },
+      body: jsonEncode({}),
+    );
+
+    if (response.statusCode != 201 && response.statusCode != 200) {
+      final body = response.body;
+      SentryLogger.info(
+        'Stream stop recording error: $body',
+        context: 'StreamService.stopRecording',
+      );
+      throw Exception(
+        'Failed to stop recording: ${response.statusCode}',
+      );
+    }
+  }
+
+  /// List recordings for a call.
+  ///
+  /// See: https://getstream.io/video/docs/api/recording/list/
+  Future<List<Map<String, dynamic>>> listRecordings(
+    String callId,
+  ) async {
+    if (!isConfigured) {
+      throw StateError('Stream API key and secret must be configured');
+    }
+
+    final serverToken = _createServerToken();
+    final response = await http.get(
+      Uri.parse(
+        '$_videoApiBaseUrl/api/v2/video/call/default/$callId'
+        '/recordings',
+      ),
+      headers: {
+        'Authorization': serverToken,
+        'Stream-Auth-Type': 'jwt',
+        'api_key': _apiKey,
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to list recordings: ${response.statusCode}',
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final recordings = data['recordings'] as List<dynamic>?;
+    return recordings?.cast<Map<String, dynamic>>() ?? [];
+  }
 }
 
 /// Data class for Stream token response

--- a/backend/routes/api/stream/recordings/start.dart
+++ b/backend/routes/api/stream/recordings/start.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:backend/services/stream_service.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
@@ -7,7 +8,6 @@ import 'package:dart_frog/dart_frog.dart';
 /// POST /api/stream/recordings/start — Start recording a meeting
 ///
 /// Body: { "callId": "..." }
-/// This delegates to the Stream SDK to start recording.
 Future<Response> onRequest(RequestContext context) async {
   if (context.request.method != HttpMethod.post) {
     return Response(statusCode: HttpStatus.methodNotAllowed);
@@ -32,9 +32,8 @@ Future<Response> onRequest(RequestContext context) async {
       );
     }
 
-    // TODO: Call Stream SDK to start recording
-    // final streamService = context.read<StreamService>();
-    // await streamService.startRecording(callId);
+    final streamService = context.read<StreamService>();
+    await streamService.startRecording(callId);
 
     return Response.json(
       body: {'message': 'Recording started', 'callId': callId},

--- a/backend/routes/api/stream/recordings/stop.dart
+++ b/backend/routes/api/stream/recordings/stop.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:backend/services/stream_service.dart';
 import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
@@ -31,9 +32,8 @@ Future<Response> onRequest(RequestContext context) async {
       );
     }
 
-    // TODO: Call Stream SDK to stop recording
-    // final streamService = context.read<StreamService>();
-    // await streamService.stopRecording(callId);
+    final streamService = context.read<StreamService>();
+    await streamService.stopRecording(callId);
 
     return Response.json(
       body: {'message': 'Recording stopped', 'callId': callId},

--- a/backend/routes/api/stream/recordings/sync.dart
+++ b/backend/routes/api/stream/recordings/sync.dart
@@ -51,38 +51,49 @@ Future<Response> onRequest(RequestContext context) async {
     final streamRecordings =
         await streamService.listRecordings(callId);
 
-    // Sync each recording to our DB
+    // Sync all recordings in a single transaction
     final now = DateTime.now().toUtc().toIso8601String();
-    final synced = <Map<String, dynamic>>[];
+    final syncCount = await db.executeInTransaction((txn) async {
+      var count = 0;
+      for (final rec in streamRecordings) {
+        final recId = rec['id'] as String?;
+        final streamUrl = rec['url'] as String?;
+        final filename = rec['filename'] as String?;
 
-    for (final rec in streamRecordings) {
-      final streamUrl = rec['url'] as String?;
-      final filename = rec['filename'] as String?;
+        final query = JsonQueryBuilder()
+            .model('Recording')
+            .action(QueryAction.create)
+            .data({
+          'meetingSessionId': meetingSessionId,
+          'streamRecordingId': recId,
+          'streamUrl': streamUrl,
+          'fileName': filename ?? 'recording-$recId',
+          'status': 'AVAILABLE',
+          'duration': rec['duration'] as int?,
+          'fileSize': rec['file_size'] as int?,
+          'createdAt': now,
+          'updatedAt': now,
+        }).build();
 
-      final query = JsonQueryBuilder()
-          .model('Recording')
-          .action(QueryAction.create)
-          .data({
-        'meetingSessionId': meetingSessionId,
-        'streamRecordingId': rec['id'],
-        'streamUrl': streamUrl,
-        'fileName': filename ?? 'recording',
-        'status': 'AVAILABLE',
-        'duration': rec['duration'] as int?,
-        'fileSize': rec['file_size'] as int?,
-        'createdAt': now,
-        'updatedAt': now,
-      }).build();
+        await txn.executeMutation(query);
+        count++;
+      }
+      return count;
+    });
 
-      final result =
-          await db.executor.executeQueryAsSingleMap(query);
-      if (result != null) synced.add(result);
-    }
+    // Fetch the synced records
+    final recordsQuery = JsonQueryBuilder()
+        .model('Recording')
+        .action(QueryAction.findMany)
+        .where({'meetingSessionId': meetingSessionId})
+        .build();
+    final records =
+        await db.executor.executeQueryAsMaps(recordsQuery);
 
     return Response.json(
       body: {
-        'synced': synced.length,
-        'data': synced.map(serializeForJson).toList(),
+        'synced': syncCount,
+        'data': records.map(serializeForJson).toList(),
       },
     );
   } catch (e, stackTrace) {

--- a/backend/routes/api/stream/recordings/sync.dart
+++ b/backend/routes/api/stream/recordings/sync.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/services/stream_service.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// POST /api/stream/recordings/sync — Sync recording metadata from Stream
+///
+/// Body: { "callId": "...", "meetingSessionId": "..." }
+///
+/// Fetches recording list from Stream Video API and creates/updates
+/// Recording records in our database.
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final callId = body['callId'] as String?;
+    final meetingSessionId =
+        body['meetingSessionId'] as String?;
+
+    if (callId == null || meetingSessionId == null) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'error': {
+            'message': 'callId and meetingSessionId are required',
+          },
+        },
+      );
+    }
+
+    final streamService = context.read<StreamService>();
+    final db = context.read<DatabaseClient>();
+
+    // Fetch recordings from Stream
+    final streamRecordings =
+        await streamService.listRecordings(callId);
+
+    // Sync each recording to our DB
+    final now = DateTime.now().toUtc().toIso8601String();
+    final synced = <Map<String, dynamic>>[];
+
+    for (final rec in streamRecordings) {
+      final streamUrl = rec['url'] as String?;
+      final filename = rec['filename'] as String?;
+
+      final query = JsonQueryBuilder()
+          .model('Recording')
+          .action(QueryAction.create)
+          .data({
+        'meetingSessionId': meetingSessionId,
+        'streamRecordingId': rec['id'],
+        'streamUrl': streamUrl,
+        'fileName': filename ?? 'recording',
+        'status': 'AVAILABLE',
+        'duration': rec['duration'] as int?,
+        'fileSize': rec['file_size'] as int?,
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+
+      final result =
+          await db.executor.executeQueryAsSingleMap(query);
+      if (result != null) synced.add(result);
+    }
+
+    return Response.json(
+      body: {
+        'synced': synced.length,
+        'data': synced.map(serializeForJson).toList(),
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe(
+      'Recording sync failed',
+      context: 'RecordingSync',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to sync recordings'}},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Replaces TODO placeholders with real Stream Video API integration for meeting recording.

### StreamService additions
- `startRecording(callId)` — POST to Stream Video API `/start_recording`
- `stopRecording(callId)` — POST to Stream Video API `/stop_recording`  
- `listRecordings(callId)` — GET recordings list for a call

### Route updates
| Route | Before | After |
|-------|--------|-------|
| `POST /api/stream/recordings/start` | TODO comment | Calls `streamService.startRecording(callId)` |
| `POST /api/stream/recordings/stop` | TODO comment | Calls `streamService.stopRecording(callId)` |
| `POST /api/stream/recordings/sync` | (new) | Fetches from Stream + creates DB records |

### Notes
- Uses Stream Video API v2 (`video.stream-io-api.com`)
- Server-side JWT auth (same pattern as existing Chat API)
- Requires `STREAM_API_KEY` and `STREAM_API_SECRET` env vars (already configured for chat)

## Test plan
- [x] Backend tests pass (0 regressions)
- [x] `dart analyze` clean
- [ ] Manual: start/stop recording during a call (requires active Stream plan with recording enabled)
- [ ] Manual: sync recordings after a call

🤖 Generated with [Claude Code](https://claude.com/claude-code)