### PR TITLE
feature: dashboard enrichment, checkout enhancements, staff completion

### DIFF
--- a/backend/routes/api/dashboard/consultant/[consultantId]/index.dart
+++ b/backend/routes/api/dashboard/consultant/[consultantId]/index.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/dashboard/consultant/:consultantId — Full consultant dashboard
+Future<Response> onRequest(
+  RequestContext context,
+  String consultantId,
+) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    // Verify ownership or staff/admin
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    final userCpId = user?['consultantProfileId'] as String?;
+    if (userCpId != consultantId &&
+        role != 'STAFF' &&
+        role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Access denied'}},
+      );
+    }
+
+    // Fetch dashboard data in parallel
+    final appointmentsQuery = JsonQueryBuilder()
+        .model('Appointment')
+        .action(QueryAction.findMany)
+        .where({'consultantProfileId': consultantId})
+        .build();
+
+    final activitiesQuery = JsonQueryBuilder()
+        .model('ActivityLog')
+        .action(QueryAction.findMany)
+        .where({'consultantProfileId': consultantId})
+        .build();
+
+    final appointments =
+        await db.executor.executeQueryAsMaps(appointmentsQuery);
+    final activities =
+        await db.executor.executeQueryAsMaps(activitiesQuery);
+
+    return Response.json(
+      body: {
+        'data': {
+          'appointments':
+              appointments.map(serializeForJson).toList(),
+          'activities':
+              activities.map(serializeForJson).toList(),
+        },
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Consultant dashboard failed',
+        context: 'ConsultantDashboard',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load dashboard'}},
+    );
+  }
+}

--- a/backend/routes/api/dashboard/consultee/[consulteeId]/index.dart
+++ b/backend/routes/api/dashboard/consultee/[consulteeId]/index.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/dashboard/consultee/:consulteeId — Full consultee dashboard
+Future<Response> onRequest(
+  RequestContext context,
+  String consulteeId,
+) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    final userCeId = user?['consulteeProfileId'] as String?;
+    if (userCeId != consulteeId &&
+        role != 'STAFF' &&
+        role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Access denied'}},
+      );
+    }
+
+    // Fetch bookings by type
+    final consultationsQuery = JsonQueryBuilder()
+        .model('Consultation')
+        .action(QueryAction.findMany)
+        .where({'requestedById': consulteeId})
+        .build();
+    final consultations =
+        await db.executor.executeQueryAsMaps(consultationsQuery);
+
+    final subscriptionsQuery = JsonQueryBuilder()
+        .model('Subscription')
+        .action(QueryAction.findMany)
+        .where({'requestedById': consulteeId})
+        .build();
+    final subscriptions =
+        await db.executor.executeQueryAsMaps(subscriptionsQuery);
+
+    return Response.json(
+      body: {
+        'data': {
+          'consultations':
+              consultations.map(serializeForJson).toList(),
+          'subscriptions':
+              subscriptions.map(serializeForJson).toList(),
+        },
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Consultee dashboard failed',
+        context: 'ConsulteeDashboard',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to load dashboard'}},
+    );
+  }
+}

--- a/backend/routes/api/invoices/[id]/index.dart
+++ b/backend/routes/api/invoices/[id]/index.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/invoices/:id — View invoice by ID or invoice number
+Future<Response> onRequest(RequestContext context, String id) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+
+    // Try by ID first, then by invoice number
+    var query = JsonQueryBuilder()
+        .model('Invoice')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    var invoice = await db.executor.executeQueryAsSingleMap(query);
+
+    if (invoice == null) {
+      query = JsonQueryBuilder()
+          .model('Invoice')
+          .action(QueryAction.findFirst)
+          .where({'invoiceNumber': id})
+          .build();
+      invoice = await db.executor.executeQueryAsSingleMap(query);
+    }
+
+    if (invoice == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Invoice not found'}},
+      );
+    }
+
+    // Authorization: user's own invoice or admin
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    final invoiceUserId = invoice['userId'] as String?;
+    if (invoiceUserId != userId && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Invoice not found'}},
+      );
+    }
+
+    return Response.json(
+      body: {'data': serializeForJson(invoice)},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Invoice get failed',
+        context: 'InvoiceGet',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to get invoice'}},
+    );
+  }
+}

--- a/backend/routes/api/payments/discounts/validate.dart
+++ b/backend/routes/api/payments/discounts/validate.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// POST /api/payments/discounts/validate — Validate a discount code
+///
+/// Body: { "code": "SAVE10", "amount": 1000 }
+/// Response: { valid, code, discountType, discountValue, discountAmount }
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final code = (body['code'] as String?)?.toUpperCase().trim();
+    final amount = (body['amount'] as num?)?.toDouble();
+
+    if (code == null || code.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'error': {'message': 'code is required'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final query = JsonQueryBuilder()
+        .model('DiscountCode')
+        .action(QueryAction.findFirst)
+        .where({'code': code})
+        .build();
+    final discount =
+        await db.executor.executeQueryAsSingleMap(query);
+
+    if (discount == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'valid': false, 'message': 'Code not found'},
+      );
+    }
+
+    // Check active
+    if (discount['isActive'] != true) {
+      return Response.json(
+        body: {'valid': false, 'message': 'Code is inactive'},
+      );
+    }
+
+    // Check expiry
+    final expiresAt = discount['expiresAt'];
+    if (expiresAt != null) {
+      final expiry = expiresAt is DateTime
+          ? expiresAt
+          : DateTime.tryParse(expiresAt.toString());
+      if (expiry != null && expiry.isBefore(DateTime.now().toUtc())) {
+        return Response.json(
+          body: {'valid': false, 'message': 'Code has expired'},
+        );
+      }
+    }
+
+    // Check max uses
+    final maxUses = discount['maxUses'] as int?;
+    final currentUses = discount['currentUses'] as int? ?? 0;
+    if (maxUses != null && currentUses >= maxUses) {
+      return Response.json(
+        body: {
+          'valid': false,
+          'message': 'Code usage limit reached',
+        },
+      );
+    }
+
+    // Calculate discount
+    final discountType = discount['discountType'] as String?;
+    final discountValue =
+        (discount['discountValue'] as num?)?.toDouble() ?? 0;
+    final maxDiscount =
+        (discount['maxDiscount'] as num?)?.toDouble();
+
+    double? discountAmount;
+    if (amount != null) {
+      if (discountType == 'PERCENTAGE') {
+        discountAmount = amount * discountValue / 100;
+        if (maxDiscount != null && discountAmount > maxDiscount) {
+          discountAmount = maxDiscount;
+        }
+      } else {
+        // FIXED_AMOUNT
+        discountAmount =
+            discountValue < amount ? discountValue : amount;
+      }
+    }
+
+    return Response.json(
+      body: {
+        'valid': true,
+        'code': code,
+        'discountType': discountType,
+        'discountValue': discountValue,
+        'discountAmount': discountAmount,
+        'maxDiscount': maxDiscount,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Discount validation failed',
+        context: 'DiscountValidate',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to validate code'}},
+    );
+  }
+}

--- a/backend/routes/api/staff/feedbacks/[feedbackId]/index.dart
+++ b/backend/routes/api/staff/feedbacks/[feedbackId]/index.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// PUT /api/staff/feedbacks/:feedbackId — Update feedback status
+Future<Response> onRequest(
+  RequestContext context,
+  String feedbackId,
+) async {
+  if (context.request.method != HttpMethod.put) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    if (role != 'STAFF' && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Staff access required'}},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final data = <String, dynamic>{
+      'updatedAt': DateTime.now().toUtc().toIso8601String(),
+    };
+    if (body.containsKey('status')) data['status'] = body['status'];
+
+    final query = JsonQueryBuilder()
+        .model('feedbacks')
+        .action(QueryAction.update)
+        .where({'id': feedbackId})
+        .data(data)
+        .build();
+    final updated =
+        await db.executor.executeQueryAsSingleMap(query);
+
+    return Response.json(
+      body: {
+        'data': updated != null ? serializeForJson(updated) : null,
+      },
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Staff feedback update failed',
+        context: 'StaffFeedbackPut',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to update feedback'}},
+    );
+  }
+}

--- a/backend/routes/api/staff/feedbacks/index.dart
+++ b/backend/routes/api/staff/feedbacks/index.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/staff/feedbacks — List feedbacks for staff review
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    if (role != 'STAFF' && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Staff access required'}},
+      );
+    }
+
+    final query = JsonQueryBuilder()
+        .model('feedbacks')
+        .action(QueryAction.findMany)
+        .where({})
+        .build();
+    final feedbacks = await db.executor.executeQueryAsMaps(query);
+
+    return Response.json(
+      body: {'data': feedbacks.map(serializeForJson).toList()},
+    );
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Staff feedbacks failed',
+        context: 'StaffFeedbacks',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Failed to list feedbacks'}},
+    );
+  }
+}

--- a/backend/routes/api/staff/support-tickets/[ticketId]/index.dart
+++ b/backend/routes/api/staff/support-tickets/[ticketId]/index.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/staff/support-tickets/:ticketId — Ticket details
+/// PUT /api/staff/support-tickets/:ticketId — Update ticket status
+Future<Response> onRequest(
+  RequestContext context,
+  String ticketId,
+) async {
+  final method = context.request.method;
+
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    if (role != 'STAFF' && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Staff access required'}},
+      );
+    }
+
+    if (method == HttpMethod.get) {
+      final query = JsonQueryBuilder()
+          .model('support_tickets')
+          .action(QueryAction.findFirst)
+          .where({'id': ticketId})
+          .build();
+      final ticket =
+          await db.executor.executeQueryAsSingleMap(query);
+      if (ticket == null) {
+        return Response.json(
+          statusCode: HttpStatus.notFound,
+          body: {'error': {'message': 'Ticket not found'}},
+        );
+      }
+      return Response.json(
+        body: {'data': serializeForJson(ticket)},
+      );
+    }
+
+    if (method == HttpMethod.put) {
+      final body =
+          await context.request.json() as Map<String, dynamic>;
+      final data = <String, dynamic>{
+        'updatedAt':
+            DateTime.now().toUtc().toIso8601String(),
+      };
+      if (body.containsKey('status')) {
+        data['status'] = body['status'];
+      }
+      if (body.containsKey('priority')) {
+        data['priority'] = body['priority'];
+      }
+      if (body.containsKey('assignedToId')) {
+        data['assignedToId'] = body['assignedToId'];
+      }
+
+      final query = JsonQueryBuilder()
+          .model('support_tickets')
+          .action(QueryAction.update)
+          .where({'id': ticketId})
+          .data(data)
+          .build();
+      final updated =
+          await db.executor.executeQueryAsSingleMap(query);
+      return Response.json(
+        body: {
+          'data':
+              updated != null ? serializeForJson(updated) : null,
+        },
+      );
+    }
+
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Staff ticket operation failed',
+        context: 'StaffTicket',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Operation failed'}},
+    );
+  }
+}

--- a/backend/routes/api/staff/support-tickets/[ticketId]/responses.dart
+++ b/backend/routes/api/staff/support-tickets/[ticketId]/responses.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:backend/database/database_client.dart';
+import 'package:backend/utils/auth_utils.dart';
+import 'package:backend/utils/json_utils.dart';
+import 'package:backend/utils/sentry_logger.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+
+/// GET /api/staff/support-tickets/:ticketId/responses — List
+/// POST /api/staff/support-tickets/:ticketId/responses — Add response
+Future<Response> onRequest(
+  RequestContext context,
+  String ticketId,
+) async {
+  try {
+    final userId = getUserIdFromToken(context);
+    if (userId == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'error': {'message': 'Unauthorized'}},
+      );
+    }
+
+    final db = context.read<DatabaseClient>();
+    final user = await db.users.findById(userId);
+    final role = user?['role'] as String?;
+    if (role != 'STAFF' && role != 'ADMIN') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Staff access required'}},
+      );
+    }
+
+    if (context.request.method == HttpMethod.get) {
+      final query = JsonQueryBuilder()
+          .model('SupportResponse')
+          .action(QueryAction.findMany)
+          .where({'supportTicketId': ticketId})
+          .build();
+      final responses =
+          await db.executor.executeQueryAsMaps(query);
+      return Response.json(
+        body: {
+          'data': responses.map(serializeForJson).toList(),
+        },
+      );
+    }
+
+    if (context.request.method == HttpMethod.post) {
+      final body =
+          await context.request.json() as Map<String, dynamic>;
+      final message = body['message'] as String?;
+      if (message == null || message.isEmpty) {
+        return Response.json(
+          statusCode: HttpStatus.badRequest,
+          body: {'error': {'message': 'message is required'}},
+        );
+      }
+
+      final now = DateTime.now().toUtc().toIso8601String();
+      final query = JsonQueryBuilder()
+          .model('SupportResponse')
+          .action(QueryAction.create)
+          .data({
+        'supportTicketId': ticketId,
+        'userId': userId,
+        'message': message,
+        'isStaffResponse': true,
+        'createdAt': now,
+        'updatedAt': now,
+      }).build();
+      final result =
+          await db.executor.executeQueryAsSingleMap(query);
+
+      return Response.json(
+        statusCode: HttpStatus.created,
+        body: {
+          'data':
+              result != null ? serializeForJson(result) : null,
+        },
+      );
+    }
+
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  } catch (e, stackTrace) {
+    await SentryLogger.severe('Staff ticket responses failed',
+        context: 'StaffTicketResponses',
+        error: e, stackTrace: stackTrace);
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'error': {'message': 'Operation failed'}},
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Three feature groups completing the mobile-web sync:

### Dashboard Enrichment (2 routes)
- `GET /api/dashboard/consultant/:id` — appointments + activity log
- `GET /api/dashboard/consultee/:id` — consultations + subscriptions
- Auth: own profile or STAFF/ADMIN

### Checkout Enhancements (2 routes)
- `POST /api/payments/discounts/validate` — validate code, calculate discount (PERCENTAGE with maxDiscount cap, or FIXED_AMOUNT)
- `GET /api/invoices/:id` — view by ID or invoice number (own invoices or ADMIN)

### Staff Dashboard Completion (4 routes)
- `GET/PUT /api/staff/support-tickets/:ticketId` — view/update
- `GET/POST /api/staff/support-tickets/:ticketId/responses` — respond
- `GET /api/staff/feedbacks` — list all
- `PUT /api/staff/feedbacks/:feedbackId` — update status

All staff routes verify STAFF/ADMIN role.

## Test plan
- [x] `dart analyze` clean (0 errors)
- [ ] Manual: validate discount code
- [ ] Manual: view invoice
- [ ] Manual: staff responds to ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)