### PR TITLE
fix: add ownership checks to slot update/delete routes

### DIFF
--- a/backend/routes/api/slots/availability/custom/[id]/index.dart
+++ b/backend/routes/api/slots/availability/custom/[id]/index.dart
@@ -5,63 +5,25 @@ import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// PUT /api/slots/availability/custom/:id — Update
 /// DELETE /api/slots/availability/custom/:id — Delete
 Future<Response> onRequest(RequestContext context, String id) async {
-  if (context.request.method == HttpMethod.put) {
-    return _handlePut(context, id);
-  }
-  if (context.request.method == HttpMethod.delete) {
-    return _handleDelete(context, id);
+  final method = context.request.method;
+
+  if (method == HttpMethod.put || method == HttpMethod.delete) {
+    return _handle(context, id, method);
   }
 
   return Response(statusCode: HttpStatus.methodNotAllowed);
 }
 
-Future<Response> _handlePut(RequestContext context, String id) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final body = await context.request.json() as Map<String, dynamic>;
-    final db = context.read<DatabaseClient>();
-
-    final updated = await db.slots.updateCustomSlot(
-      id: id,
-      startsAt: body['startsAt'] as String?,
-      endsAt: body['endsAt'] as String?,
-    );
-
-    if (updated == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Slot not found'}},
-      );
-    }
-
-    return Response.json(
-      body: {'data': serializeForJson(updated)},
-    );
-  } catch (e, stackTrace) {
-    await SentryLogger.severe('Update custom slot failed',
-        context: 'CustomSlotPut',
-        error: e, stackTrace: stackTrace);
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to update slot'}},
-    );
-  }
-}
-
-Future<Response> _handleDelete(
+/// Shared auth + ownership check for update/delete.
+Future<Response> _handle(
   RequestContext context,
   String id,
+  HttpMethod method,
 ) async {
   try {
     final userId = getUserIdFromToken(context);
@@ -73,16 +35,61 @@ Future<Response> _handleDelete(
     }
 
     final db = context.read<DatabaseClient>();
-    await db.slots.deleteCustomSlot(id);
 
+    // Verify ownership
+    final user = await db.users.findById(userId);
+    final userCpId = user?['consultantProfileId'] as String?;
+    if (userCpId == null) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Not a consultant'}},
+      );
+    }
+
+    final slotQuery = JsonQueryBuilder()
+        .model('SlotOfAvailabilityCustom')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    final slot =
+        await db.executor.executeQueryAsSingleMap(slotQuery);
+
+    if (slot == null || slot['consultantProfileId'] != userCpId) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Slot not found'}},
+      );
+    }
+
+    if (method == HttpMethod.put) {
+      final body =
+          await context.request.json() as Map<String, dynamic>;
+      final updated = await db.slots.updateCustomSlot(
+        id: id,
+        startsAt: body['startsAt'] as String?,
+        endsAt: body['endsAt'] as String?,
+      );
+      return Response.json(
+        body: {
+          'data':
+              updated != null ? serializeForJson(updated) : null,
+        },
+      );
+    }
+
+    // DELETE
+    await db.slots.deleteCustomSlot(id);
     return Response.json(body: {'message': 'Slot deleted'});
   } catch (e, stackTrace) {
-    await SentryLogger.severe('Delete custom slot failed',
-        context: 'CustomSlotDel',
-        error: e, stackTrace: stackTrace);
+    await SentryLogger.severe(
+      'Custom slot operation failed',
+      context: 'CustomSlot',
+      error: e,
+      stackTrace: stackTrace,
+    );
     return Response.json(
       statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to delete slot'}},
+      body: {'error': {'message': 'Operation failed'}},
     );
   }
 }

--- a/backend/routes/api/slots/availability/weekly/[id]/index.dart
+++ b/backend/routes/api/slots/availability/weekly/[id]/index.dart
@@ -5,65 +5,25 @@ import 'package:backend/utils/auth_utils.dart';
 import 'package:backend/utils/json_utils.dart';
 import 'package:backend/utils/sentry_logger.dart';
 import 'package:dart_frog/dart_frog.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 
 /// PUT /api/slots/availability/weekly/:id — Update
 /// DELETE /api/slots/availability/weekly/:id — Delete
 Future<Response> onRequest(RequestContext context, String id) async {
-  if (context.request.method == HttpMethod.put) {
-    return _handlePut(context, id);
-  }
-  if (context.request.method == HttpMethod.delete) {
-    return _handleDelete(context, id);
+  final method = context.request.method;
+
+  if (method == HttpMethod.put || method == HttpMethod.delete) {
+    return _handle(context, id, method);
   }
 
   return Response(statusCode: HttpStatus.methodNotAllowed);
 }
 
-Future<Response> _handlePut(RequestContext context, String id) async {
-  try {
-    final userId = getUserIdFromToken(context);
-    if (userId == null) {
-      return Response.json(
-        statusCode: HttpStatus.unauthorized,
-        body: {'error': {'message': 'Unauthorized'}},
-      );
-    }
-
-    final body = await context.request.json() as Map<String, dynamic>;
-    final db = context.read<DatabaseClient>();
-
-    final updated = await db.slots.updateWeeklySlot(
-      id: id,
-      startDay: body['startDay'] as String?,
-      endDay: body['endDay'] as String?,
-      startTimeUtc: (body['startTimeUtc'] as num?)?.toInt(),
-      endTimeUtc: (body['endTimeUtc'] as num?)?.toInt(),
-    );
-
-    if (updated == null) {
-      return Response.json(
-        statusCode: HttpStatus.notFound,
-        body: {'error': {'message': 'Slot not found'}},
-      );
-    }
-
-    return Response.json(
-      body: {'data': serializeForJson(updated)},
-    );
-  } catch (e, stackTrace) {
-    await SentryLogger.severe('Update weekly slot failed',
-        context: 'WeeklySlotPut',
-        error: e, stackTrace: stackTrace);
-    return Response.json(
-      statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to update slot'}},
-    );
-  }
-}
-
-Future<Response> _handleDelete(
+/// Shared auth + ownership check for update/delete.
+Future<Response> _handle(
   RequestContext context,
   String id,
+  HttpMethod method,
 ) async {
   try {
     final userId = getUserIdFromToken(context);
@@ -75,16 +35,70 @@ Future<Response> _handleDelete(
     }
 
     final db = context.read<DatabaseClient>();
-    await db.slots.deleteWeeklySlot(id);
 
+    // Verify ownership: fetch slot, check consultantProfileId
+    final user = await db.users.findById(userId);
+    final userCpId = user?['consultantProfileId'] as String?;
+    if (userCpId == null) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'error': {'message': 'Not a consultant'}},
+      );
+    }
+
+    final slotQuery = JsonQueryBuilder()
+        .model('SlotOfAvailabilityWeekly')
+        .action(QueryAction.findFirst)
+        .where({'id': id})
+        .build();
+    final slot =
+        await db.executor.executeQueryAsSingleMap(slotQuery);
+
+    if (slot == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Slot not found'}},
+      );
+    }
+
+    if (slot['consultantProfileId'] != userCpId) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'error': {'message': 'Slot not found'}},
+      );
+    }
+
+    if (method == HttpMethod.put) {
+      final body =
+          await context.request.json() as Map<String, dynamic>;
+      final updated = await db.slots.updateWeeklySlot(
+        id: id,
+        startDay: body['startDay'] as String?,
+        endDay: body['endDay'] as String?,
+        startTimeUtc: (body['startTimeUtc'] as num?)?.toInt(),
+        endTimeUtc: (body['endTimeUtc'] as num?)?.toInt(),
+      );
+      return Response.json(
+        body: {
+          'data':
+              updated != null ? serializeForJson(updated) : null,
+        },
+      );
+    }
+
+    // DELETE
+    await db.slots.deleteWeeklySlot(id);
     return Response.json(body: {'message': 'Slot deleted'});
   } catch (e, stackTrace) {
-    await SentryLogger.severe('Delete weekly slot failed',
-        context: 'WeeklySlotDel',
-        error: e, stackTrace: stackTrace);
+    await SentryLogger.severe(
+      'Weekly slot operation failed',
+      context: 'WeeklySlot',
+      error: e,
+      stackTrace: stackTrace,
+    );
     return Response.json(
       statusCode: HttpStatus.internalServerError,
-      body: {'error': {'message': 'Failed to delete slot'}},
+      body: {'error': {'message': 'Operation failed'}},
     );
   }
 }


### PR DESCRIPTION
## Summary
Security fix for PR #81 review feedback — slot update/delete routes were missing ownership verification.

**Before:** Any authenticated user could modify/delete any weekly or custom slot by ID.
**After:** Fetch slot first, verify `consultantProfileId` matches user's profile. Return 404 to avoid leaking existence.

## Files Changed
- `backend/routes/api/slots/availability/weekly/[id]/index.dart`
- `backend/routes/api/slots/availability/custom/[id]/index.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)