### PR TITLE
fix: 3 Sentry issues — announcements, feedback ID, GoRouter pop

### DIFF
--- a/backend/lib/database/repositories/announcement_repository.dart
+++ b/backend/lib/database/repositories/announcement_repository.dart
@@ -15,7 +15,7 @@ class AnnouncementRepository extends BaseRepository {
       'isActive': true,
       'startDate': {'lte': now},
       'OR': [
-        {'endDate': null},
+        {'endDate': {'equals': null}},
         {'endDate': {'gte': now}},
       ],
     }).build();

--- a/backend/lib/database/repositories/feedback_repository.dart
+++ b/backend/lib/database/repositories/feedback_repository.dart
@@ -1,5 +1,7 @@
 import 'package:backend/database/repositories/base_repository.dart';
 import 'package:backend/generated/index.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
+import 'package:uuid/uuid.dart';
 
 /// Repository for app feedback operations using typed PrismaClient delegates
 ///
@@ -23,18 +25,28 @@ class FeedbackRepository extends BaseRepository {
     String? category,
     int? rating,
   }) async {
-    final feedback = await _prisma.feedback.create(
-      data: CreateFeedbackInput(
-        userId: userId,
-        title: title,
-        description: description,
-        category: category,
-        rating: rating != null ? rating.clamp(1, 5) : null,
-        status: FeedbackStatus.pending,
-      ),
-    );
+    // Use JsonQueryBuilder with explicit id — the Prisma Flutter
+    // Connector doesn't auto-generate @default(uuid()) IDs.
+    const uuid = Uuid();
+    final now = nowIso8601;
+    final query = JsonQueryBuilder()
+        .model('Feedback')
+        .action(QueryAction.create)
+        .data({
+      'id': uuid.v4(),
+      'userId': userId,
+      'title': title,
+      'description': description,
+      'category': category,
+      'rating': rating != null ? rating.clamp(1, 5) : null,
+      'status': 'PENDING',
+      'createdAt': now,
+      'updatedAt': now,
+    }).build();
 
-    return feedback.toJson();
+    final result = await executeQueryAsSingleMap(query);
+    if (result == null) throw Exception('Failed to create feedback');
+    return result;
   }
 
   /// Get feedback submitted by a user

--- a/lib/features/feedback/screens/feedback_screen.dart
+++ b/lib/features/feedback/screens/feedback_screen.dart
@@ -53,7 +53,11 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
           backgroundColor: Colors.green.shade600,
         ),
       );
-      context.pop();
+      if (context.canPop()) {
+        context.pop();
+      } else {
+        context.go('/dashboard');
+      }
     } else if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
## Sentry Issues Fixed
- **MOBILE-4R**: Announcements null filter — `{'endDate': null}` → `{'endDate': {'equals': null}}`
- **MOBILE-4C/4D**: Feedback null ID — switch to JsonQueryBuilder with uuid.v4()
- **MOBILE-4E**: GoRouter pop crash — use canPop() guard

Fixes #90 #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)