### PR TITLE
fix: remove ghost fields from ConsulteeProfile schema registry

### DIFF
--- a/backend/lib/database/schema_registry_builder.dart
+++ b/backend/lib/database/schema_registry_builder.dart
@@ -291,31 +291,21 @@ SchemaRegistry buildSchemaRegistry() {
   schema.registerModel(ModelSchema(
     name: 'ConsulteeProfile',
     tableName: 'ConsulteeProfile',
+    // Only columns that exist in the DB (no occupation, currentCompany,
+    // industry, linkedinUrl, preferredCommunicationMethod — see PR #88)
     fields: {
       'id': FieldInfo.id(name: 'id'),
       'userId':
           const FieldInfo(name: 'userId', columnName: 'userId', type: 'String'),
-      'occupation': const FieldInfo(
-          name: 'occupation', columnName: 'occupation', type: 'String'),
       'aboutMe': const FieldInfo(
           name: 'aboutMe', columnName: 'aboutMe', type: 'String'),
       'careerStage': const FieldInfo(
           name: 'careerStage', columnName: 'careerStage', type: 'String'),
-      'currentCompany': const FieldInfo(
-          name: 'currentCompany', columnName: 'currentCompany', type: 'String'),
-      'industry': const FieldInfo(
-          name: 'industry', columnName: 'industry', type: 'String'),
       'skillsToDevelop': const FieldInfo(
           name: 'skillsToDevelop', columnName: 'skillsToDevelop', type: 'Json'),
-      'linkedinUrl': const FieldInfo(
-          name: 'linkedinUrl', columnName: 'linkedinUrl', type: 'String'),
       'budgetPreference': const FieldInfo(
           name: 'budgetPreference',
           columnName: 'budgetPreference',
-          type: 'String'),
-      'preferredCommunicationMethod': const FieldInfo(
-          name: 'preferredCommunicationMethod',
-          columnName: 'preferredCommunicationMethod',
           type: 'String'),
       'preferredLanguage': const FieldInfo(
           name: 'preferredLanguage',


### PR DESCRIPTION
Schema registry listed occupation, currentCompany, industry, linkedinUrl, preferredCommunicationMethod on ConsulteeProfile — these columns don't exist in DB.

Caused 500 on any query JOINing ConsulteeProfile (schedule, bookings, dashboard stats).

Sentry: MOBILE-4X

🤖 Generated with [Claude Code](https://claude.com/claude-code)