### PR TITLE
fix: add bottom navigation + back buttons to all feature screens

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -353,27 +353,159 @@ GoRouter router(Ref ref) {
               );
             },
           ),
-        ],
-      ),
+          // Appointment documents
+          GoRoute(
+            path: '/bookings/:bookingId/documents',
+            name: 'appointmentDocuments',
+            builder: (context, state) {
+              final appointmentId =
+                  state.uri.queryParameters['appointmentId'];
+              if (appointmentId == null) {
+                return const Scaffold(
+                  body: Center(
+                    child: Text('Missing appointmentId'),
+                  ),
+                );
+              }
+              return AppointmentDocumentsScreen(
+                appointmentId: appointmentId,
+              );
+            },
+          ),
 
-      // Appointment documents
-      GoRoute(
-        path: '/bookings/:bookingId/documents',
-        name: 'appointmentDocuments',
-        builder: (context, state) {
-          final appointmentId =
-              state.uri.queryParameters['appointmentId'];
-          if (appointmentId == null) {
-            return const Scaffold(
-              body: Center(
-                child: Text('Missing appointmentId'),
+          // Verification routes
+          GoRoute(
+            path: '/verification',
+            name: 'verification',
+            builder: (context, state) =>
+                const VerificationStatusScreen(),
+            routes: [
+              GoRoute(
+                path: 'submit',
+                name: 'verificationSubmit',
+                builder: (context, state) =>
+                    const VerificationSubmitScreen(),
               ),
-            );
-          }
-          return AppointmentDocumentsScreen(
-            appointmentId: appointmentId,
-          );
-        },
+            ],
+          ),
+
+          // Waitlist routes
+          GoRoute(
+            path: '/waitlist',
+            name: 'waitlist',
+            builder: (context, state) => const WaitlistScreen(),
+          ),
+
+          // Trial routes
+          GoRoute(
+            path: '/trials',
+            name: 'trials',
+            builder: (context, state) => const TrialListScreen(),
+            routes: [
+              GoRoute(
+                path: 'request',
+                name: 'trialRequest',
+                builder: (context, state) {
+                  final consultantProfileId =
+                      state.uri.queryParameters['consultantProfileId'];
+                  final subscriptionPlanId =
+                      state.uri.queryParameters['subscriptionPlanId'];
+                  if (consultantProfileId == null ||
+                      subscriptionPlanId == null) {
+                    return const Scaffold(
+                      body: Center(
+                        child: Text('Missing required parameters'),
+                      ),
+                    );
+                  }
+                  return TrialRequestScreen(
+                    consultantProfileId: consultantProfileId,
+                    subscriptionPlanId: subscriptionPlanId,
+                  );
+                },
+              ),
+            ],
+          ),
+
+          // Payout routes
+          GoRoute(
+            path: '/payout-accounts',
+            name: 'payoutAccounts',
+            builder: (context, state) =>
+                const PayoutAccountsScreen(),
+            routes: [
+              GoRoute(
+                path: 'add',
+                name: 'addPayoutAccount',
+                builder: (context, state) =>
+                    const AddPayoutAccountScreen(),
+              ),
+            ],
+          ),
+
+          // Tax info routes
+          GoRoute(
+            path: '/tax-info',
+            name: 'taxInfo',
+            builder: (context, state) => const TaxInfoScreen(),
+          ),
+
+          // Staff dashboard
+          GoRoute(
+            path: '/staff',
+            name: 'staffDashboard',
+            builder: (context, state) =>
+                const StaffDashboardScreen(),
+          ),
+
+          // Maintenance route
+          GoRoute(
+            path: '/maintenance',
+            name: 'maintenance',
+            builder: (context, state) =>
+                const MaintenanceScreen(),
+          ),
+
+          // Support routes
+          GoRoute(
+            path: '/support',
+            name: 'support',
+            builder: (context, state) =>
+                const SupportTicketsScreen(),
+            routes: [
+              GoRoute(
+                path: 'create',
+                name: 'createTicket',
+                builder: (context, state) {
+                  final bookingId =
+                      state.uri.queryParameters['bookingId'];
+                  final bookingType =
+                      state.uri.queryParameters['bookingType'];
+                  return CreateTicketScreen(
+                    bookingId: bookingId,
+                    bookingType: bookingType,
+                  );
+                },
+              ),
+              GoRoute(
+                path: ':ticketId',
+                name: 'ticketDetail',
+                builder: (context, state) =>
+                    SupportTicketDetailScreen(
+                  ticketId: state.pathParameters['ticketId']!,
+                ),
+              ),
+            ],
+          ),
+
+          // Feedback route
+          GoRoute(
+            path: '/feedback',
+            name: 'feedback',
+            builder: (context, state) =>
+                const FeedbackScreen(),
+          ),
+        ],
       ),
 
       // Booking routes (Phase 5)
@@ -469,130 +601,6 @@ GoRouter router(Ref ref) {
                 paramsData is DirectCheckoutParams ? paramsData : null,
           );
         },
-      ),
-
-      // Verification routes
-      GoRoute(
-        path: '/verification',
-        name: 'verification',
-        builder: (context, state) => const VerificationStatusScreen(),
-        routes: [
-          GoRoute(
-            path: 'submit',
-            name: 'verificationSubmit',
-            builder: (context, state) =>
-                const VerificationSubmitScreen(),
-          ),
-        ],
-      ),
-
-      // Waitlist routes
-      GoRoute(
-        path: '/waitlist',
-        name: 'waitlist',
-        builder: (context, state) => const WaitlistScreen(),
-      ),
-
-      // Trial routes
-      GoRoute(
-        path: '/trials',
-        name: 'trials',
-        builder: (context, state) => const TrialListScreen(),
-        routes: [
-          GoRoute(
-            path: 'request',
-            name: 'trialRequest',
-            builder: (context, state) {
-              final consultantProfileId =
-                  state.uri.queryParameters['consultantProfileId'];
-              final subscriptionPlanId =
-                  state.uri.queryParameters['subscriptionPlanId'];
-              if (consultantProfileId == null ||
-                  subscriptionPlanId == null) {
-                return const Scaffold(
-                  body: Center(
-                    child: Text('Missing required parameters'),
-                  ),
-                );
-              }
-              return TrialRequestScreen(
-                consultantProfileId: consultantProfileId,
-                subscriptionPlanId: subscriptionPlanId,
-              );
-            },
-          ),
-        ],
-      ),
-
-      // Payout routes
-      GoRoute(
-        path: '/payout-accounts',
-        name: 'payoutAccounts',
-        builder: (context, state) => const PayoutAccountsScreen(),
-        routes: [
-          GoRoute(
-            path: 'add',
-            name: 'addPayoutAccount',
-            builder: (context, state) =>
-                const AddPayoutAccountScreen(),
-          ),
-        ],
-      ),
-
-      // Tax info routes
-      GoRoute(
-        path: '/tax-info',
-        name: 'taxInfo',
-        builder: (context, state) => const TaxInfoScreen(),
-      ),
-
-      // Staff dashboard
-      GoRoute(
-        path: '/staff',
-        name: 'staffDashboard',
-        builder: (context, state) => const StaffDashboardScreen(),
-      ),
-
-      // Maintenance route
-      GoRoute(
-        path: '/maintenance',
-        name: 'maintenance',
-        builder: (context, state) => const MaintenanceScreen(),
-      ),
-
-      // Support routes (PR#15)
-      GoRoute(
-        path: '/support',
-        name: 'support',
-        builder: (context, state) => const SupportTicketsScreen(),
-        routes: [
-          GoRoute(
-            path: 'create',
-            name: 'createTicket',
-            builder: (context, state) {
-              final bookingId = state.uri.queryParameters['bookingId'];
-              final bookingType = state.uri.queryParameters['bookingType'];
-              return CreateTicketScreen(
-                bookingId: bookingId,
-                bookingType: bookingType,
-              );
-            },
-          ),
-          GoRoute(
-            path: ':ticketId',
-            name: 'ticketDetail',
-            builder: (context, state) => SupportTicketDetailScreen(
-              ticketId: state.pathParameters['ticketId']!,
-            ),
-          ),
-        ],
-      ),
-
-      // Feedback route (PR#15)
-      GoRoute(
-        path: '/feedback',
-        name: 'feedback',
-        builder: (context, state) => const FeedbackScreen(),
       ),
 
       // Meeting route (Phase 7)

--- a/lib/features/maintenance/screens/maintenance_screen.dart
+++ b/lib/features/maintenance/screens/maintenance_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class MaintenanceScreen extends StatelessWidget {
   const MaintenanceScreen({super.key});
@@ -6,6 +7,14 @@ class MaintenanceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('Maintenance'),
+        leading: BackButton(
+          onPressed: () => context.canPop()
+              ? context.pop()
+              : context.go('/dashboard'),
+        ),
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(32),

--- a/lib/features/tax/screens/tax_info_screen.dart
+++ b/lib/features/tax/screens/tax_info_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../core/utils/sentry_logger.dart';
 import '../providers/tax_provider.dart';
@@ -113,6 +114,7 @@ class _TaxInfoScreenState extends ConsumerState<TaxInfoScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Tax info saved')),
         );
+        if (context.canPop()) context.pop();
       }
     } catch (e, stack) {
       AppSentryLogger.captureException(e,


### PR DESCRIPTION
## Problem
12 screen groups were defined outside the ShellRoute, so they had no bottom navigation bar. Users got trapped with no way to navigate back to the main app.

## Fix
Moved all feature routes inside the ShellRoute:
- /verification, /trials, /waitlist
- /payout-accounts, /tax-info, /staff
- /maintenance, /support, /feedback
- /bookings/:id/documents

Also:
- Added AppBar with back button to MaintenanceScreen (had NO AppBar at all)
- Added context.pop() after successful tax info save
- Removed duplicate route definitions

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)