### PR TITLE
fix: resolve E2E bugs — signup FK, plan fromJson, notifications (#101, #102, #103)

### DIFF
--- a/backend/lib/generated/models/class_plan.dart
+++ b/backend/lib/generated/models/class_plan.dart
@@ -22,7 +22,8 @@ class ClassPlan with _$ClassPlan {
     required String description,
     @JsonKey(includeFromJson: false, includeToJson: false)
     List<Topic>? topics,
-    required List<ClassContent> classContents,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<ClassContent>? classContents,
     required int price,
     @Default("INR")
     String priceCurrency,
@@ -60,9 +61,12 @@ class ClassPlan with _$ClassPlan {
     @JsonKey(includeFromJson: false, includeToJson: false)
     ConsultantProfile? consultantProfile,
     String? consultantProfileId,
-    required List<ClassModel> classes,
-    required List<PlanMaterial> materials,
-    required List<ClassCollaborator> collaborators,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<ClassModel>? classes,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<PlanMaterial>? materials,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<ClassCollaborator>? collaborators,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _ClassPlan;

--- a/backend/lib/generated/models/class_plan.freezed.dart
+++ b/backend/lib/generated/models/class_plan.freezed.dart
@@ -25,7 +25,8 @@ mixin _$ClassPlan {
   String get description => throw _privateConstructorUsedError;
   @JsonKey(includeFromJson: false, includeToJson: false)
   List<Topic>? get topics => throw _privateConstructorUsedError;
-  List<ClassContent> get classContents => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassContent>? get classContents => throw _privateConstructorUsedError;
   int get price => throw _privateConstructorUsedError;
   String get priceCurrency => throw _privateConstructorUsedError;
   bool get certificateProvided => throw _privateConstructorUsedError;
@@ -49,9 +50,12 @@ mixin _$ClassPlan {
   ConsultantProfile? get consultantProfile =>
       throw _privateConstructorUsedError;
   String? get consultantProfileId => throw _privateConstructorUsedError;
-  List<ClassModel> get classes => throw _privateConstructorUsedError;
-  List<PlanMaterial> get materials => throw _privateConstructorUsedError;
-  List<ClassCollaborator> get collaborators =>
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassModel>? get classes => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassCollaborator>? get collaborators =>
       throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
@@ -77,7 +81,8 @@ abstract class $ClassPlanCopyWith<$Res> {
       String description,
       @JsonKey(includeFromJson: false, includeToJson: false)
       List<Topic>? topics,
-      List<ClassContent> classContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassContent>? classContents,
       int price,
       String priceCurrency,
       bool certificateProvided,
@@ -99,9 +104,12 @@ abstract class $ClassPlanCopyWith<$Res> {
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String? consultantProfileId,
-      List<ClassModel> classes,
-      List<PlanMaterial> materials,
-      List<ClassCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassModel>? classes,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassCollaborator>? collaborators,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -127,7 +135,7 @@ class _$ClassPlanCopyWithImpl<$Res, $Val extends ClassPlan>
     Object? title = null,
     Object? description = null,
     Object? topics = freezed,
-    Object? classContents = null,
+    Object? classContents = freezed,
     Object? price = null,
     Object? priceCurrency = null,
     Object? certificateProvided = null,
@@ -148,9 +156,9 @@ class _$ClassPlanCopyWithImpl<$Res, $Val extends ClassPlan>
     Object? imageUrl = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = freezed,
-    Object? classes = null,
-    Object? materials = null,
-    Object? collaborators = null,
+    Object? classes = freezed,
+    Object? materials = freezed,
+    Object? collaborators = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -171,10 +179,10 @@ class _$ClassPlanCopyWithImpl<$Res, $Val extends ClassPlan>
           ? _value.topics
           : topics // ignore: cast_nullable_to_non_nullable
               as List<Topic>?,
-      classContents: null == classContents
+      classContents: freezed == classContents
           ? _value.classContents
           : classContents // ignore: cast_nullable_to_non_nullable
-              as List<ClassContent>,
+              as List<ClassContent>?,
       price: null == price
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
@@ -255,18 +263,18 @@ class _$ClassPlanCopyWithImpl<$Res, $Val extends ClassPlan>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String?,
-      classes: null == classes
+      classes: freezed == classes
           ? _value.classes
           : classes // ignore: cast_nullable_to_non_nullable
-              as List<ClassModel>,
-      materials: null == materials
+              as List<ClassModel>?,
+      materials: freezed == materials
           ? _value.materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
-      collaborators: null == collaborators
+              as List<PlanMaterial>?,
+      collaborators: freezed == collaborators
           ? _value.collaborators
           : collaborators // ignore: cast_nullable_to_non_nullable
-              as List<ClassCollaborator>,
+              as List<ClassCollaborator>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -307,7 +315,8 @@ abstract class _$$ClassPlanImplCopyWith<$Res>
       String description,
       @JsonKey(includeFromJson: false, includeToJson: false)
       List<Topic>? topics,
-      List<ClassContent> classContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassContent>? classContents,
       int price,
       String priceCurrency,
       bool certificateProvided,
@@ -329,9 +338,12 @@ abstract class _$$ClassPlanImplCopyWith<$Res>
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String? consultantProfileId,
-      List<ClassModel> classes,
-      List<PlanMaterial> materials,
-      List<ClassCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassModel>? classes,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<ClassCollaborator>? collaborators,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -356,7 +368,7 @@ class __$$ClassPlanImplCopyWithImpl<$Res>
     Object? title = null,
     Object? description = null,
     Object? topics = freezed,
-    Object? classContents = null,
+    Object? classContents = freezed,
     Object? price = null,
     Object? priceCurrency = null,
     Object? certificateProvided = null,
@@ -377,9 +389,9 @@ class __$$ClassPlanImplCopyWithImpl<$Res>
     Object? imageUrl = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = freezed,
-    Object? classes = null,
-    Object? materials = null,
-    Object? collaborators = null,
+    Object? classes = freezed,
+    Object? materials = freezed,
+    Object? collaborators = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -400,10 +412,10 @@ class __$$ClassPlanImplCopyWithImpl<$Res>
           ? _value._topics
           : topics // ignore: cast_nullable_to_non_nullable
               as List<Topic>?,
-      classContents: null == classContents
+      classContents: freezed == classContents
           ? _value._classContents
           : classContents // ignore: cast_nullable_to_non_nullable
-              as List<ClassContent>,
+              as List<ClassContent>?,
       price: null == price
           ? _value.price
           : price // ignore: cast_nullable_to_non_nullable
@@ -484,18 +496,18 @@ class __$$ClassPlanImplCopyWithImpl<$Res>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String?,
-      classes: null == classes
+      classes: freezed == classes
           ? _value._classes
           : classes // ignore: cast_nullable_to_non_nullable
-              as List<ClassModel>,
-      materials: null == materials
+              as List<ClassModel>?,
+      materials: freezed == materials
           ? _value._materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
-      collaborators: null == collaborators
+              as List<PlanMaterial>?,
+      collaborators: freezed == collaborators
           ? _value._collaborators
           : collaborators // ignore: cast_nullable_to_non_nullable
-              as List<ClassCollaborator>,
+              as List<ClassCollaborator>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -517,7 +529,8 @@ class _$ClassPlanImpl implements _ClassPlan {
       required this.description,
       @JsonKey(includeFromJson: false, includeToJson: false)
       final List<Topic>? topics,
-      required final List<ClassContent> classContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassContent>? classContents,
       required this.price,
       this.priceCurrency = "INR",
       this.certificateProvided = false,
@@ -539,9 +552,12 @@ class _$ClassPlanImpl implements _ClassPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       this.consultantProfile,
       this.consultantProfileId,
-      required final List<ClassModel> classes,
-      required final List<PlanMaterial> materials,
-      required final List<ClassCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassModel>? classes,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassCollaborator>? collaborators,
       required this.createdAt,
       required this.updatedAt})
       : _topics = topics,
@@ -571,12 +587,15 @@ class _$ClassPlanImpl implements _ClassPlan {
     return EqualUnmodifiableListView(value);
   }
 
-  final List<ClassContent> _classContents;
+  final List<ClassContent>? _classContents;
   @override
-  List<ClassContent> get classContents {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassContent>? get classContents {
+    final value = _classContents;
+    if (value == null) return null;
     if (_classContents is EqualUnmodifiableListView) return _classContents;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_classContents);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
@@ -645,28 +664,37 @@ class _$ClassPlanImpl implements _ClassPlan {
   final ConsultantProfile? consultantProfile;
   @override
   final String? consultantProfileId;
-  final List<ClassModel> _classes;
+  final List<ClassModel>? _classes;
   @override
-  List<ClassModel> get classes {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassModel>? get classes {
+    final value = _classes;
+    if (value == null) return null;
     if (_classes is EqualUnmodifiableListView) return _classes;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_classes);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<PlanMaterial> _materials;
+  final List<PlanMaterial>? _materials;
   @override
-  List<PlanMaterial> get materials {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials {
+    final value = _materials;
+    if (value == null) return null;
     if (_materials is EqualUnmodifiableListView) return _materials;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_materials);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<ClassCollaborator> _collaborators;
+  final List<ClassCollaborator>? _collaborators;
   @override
-  List<ClassCollaborator> get collaborators {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassCollaborator>? get collaborators {
+    final value = _collaborators;
+    if (value == null) return null;
     if (_collaborators is EqualUnmodifiableListView) return _collaborators;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_collaborators);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
@@ -799,7 +827,8 @@ abstract class _ClassPlan implements ClassPlan {
       required final String description,
       @JsonKey(includeFromJson: false, includeToJson: false)
       final List<Topic>? topics,
-      required final List<ClassContent> classContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassContent>? classContents,
       required final int price,
       final String priceCurrency,
       final bool certificateProvided,
@@ -821,9 +850,12 @@ abstract class _ClassPlan implements ClassPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       final ConsultantProfile? consultantProfile,
       final String? consultantProfileId,
-      required final List<ClassModel> classes,
-      required final List<PlanMaterial> materials,
-      required final List<ClassCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassModel>? classes,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<ClassCollaborator>? collaborators,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$ClassPlanImpl;
 
@@ -840,7 +872,8 @@ abstract class _ClassPlan implements ClassPlan {
   @JsonKey(includeFromJson: false, includeToJson: false)
   List<Topic>? get topics;
   @override
-  List<ClassContent> get classContents;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassContent>? get classContents;
   @override
   int get price;
   @override
@@ -883,11 +916,14 @@ abstract class _ClassPlan implements ClassPlan {
   @override
   String? get consultantProfileId;
   @override
-  List<ClassModel> get classes;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassModel>? get classes;
   @override
-  List<PlanMaterial> get materials;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials;
   @override
-  List<ClassCollaborator> get collaborators;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<ClassCollaborator>? get collaborators;
   @override
   DateTime get createdAt;
   @override

--- a/backend/lib/generated/models/class_plan.g.dart
+++ b/backend/lib/generated/models/class_plan.g.dart
@@ -11,9 +11,6 @@ _$ClassPlanImpl _$$ClassPlanImplFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       title: json['title'] as String,
       description: json['description'] as String,
-      classContents: (json['classContents'] as List<dynamic>)
-          .map((e) => ClassContent.fromJson(e as Map<String, dynamic>))
-          .toList(),
       price: (json['price'] as num).toInt(),
       priceCurrency: json['priceCurrency'] as String? ?? "INR",
       certificateProvided: json['certificateProvided'] as bool? ?? false,
@@ -42,15 +39,6 @@ _$ClassPlanImpl _$$ClassPlanImplFromJson(Map<String, dynamic> json) =>
           const <String>[],
       imageUrl: json['imageUrl'] as String?,
       consultantProfileId: json['consultantProfileId'] as String?,
-      classes: (json['classes'] as List<dynamic>)
-          .map((e) => ClassModel.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      materials: (json['materials'] as List<dynamic>)
-          .map((e) => PlanMaterial.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      collaborators: (json['collaborators'] as List<dynamic>)
-          .map((e) => ClassCollaborator.fromJson(e as Map<String, dynamic>))
-          .toList(),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
@@ -60,7 +48,6 @@ Map<String, dynamic> _$$ClassPlanImplToJson(_$ClassPlanImpl instance) =>
       'id': instance.id,
       'title': instance.title,
       'description': instance.description,
-      'classContents': instance.classContents,
       'price': instance.price,
       'priceCurrency': instance.priceCurrency,
       'certificateProvided': instance.certificateProvided,
@@ -81,9 +68,6 @@ Map<String, dynamic> _$$ClassPlanImplToJson(_$ClassPlanImpl instance) =>
       'learningOutcomes': instance.learningOutcomes,
       'imageUrl': instance.imageUrl,
       'consultantProfileId': instance.consultantProfileId,
-      'classes': instance.classes,
-      'materials': instance.materials,
-      'collaborators': instance.collaborators,
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': instance.updatedAt.toIso8601String(),
     };

--- a/backend/lib/generated/models/consultation_plan.dart
+++ b/backend/lib/generated/models/consultation_plan.dart
@@ -36,8 +36,10 @@ class ConsultationPlan with _$ConsultationPlan {
     @JsonKey(includeFromJson: false, includeToJson: false)
     ConsultantProfile? consultantProfile,
     required String consultantProfileId,
-    required List<Consultation> consultations,
-    required List<PlanMaterial> materials,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<Consultation>? consultations,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<PlanMaterial>? materials,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _ConsultationPlan;

--- a/backend/lib/generated/models/consultation_plan.freezed.dart
+++ b/backend/lib/generated/models/consultation_plan.freezed.dart
@@ -37,8 +37,10 @@ mixin _$ConsultationPlan {
   ConsultantProfile? get consultantProfile =>
       throw _privateConstructorUsedError;
   String get consultantProfileId => throw _privateConstructorUsedError;
-  List<Consultation> get consultations => throw _privateConstructorUsedError;
-  List<PlanMaterial> get materials => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Consultation>? get consultations => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
@@ -75,8 +77,10 @@ abstract class $ConsultationPlanCopyWith<$Res> {
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String consultantProfileId,
-      List<Consultation> consultations,
-      List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Consultation>? consultations,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -112,8 +116,8 @@ class _$ConsultationPlanCopyWithImpl<$Res, $Val extends ConsultationPlan>
     Object? topics = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = null,
-    Object? consultations = null,
-    Object? materials = null,
+    Object? consultations = freezed,
+    Object? materials = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -174,14 +178,14 @@ class _$ConsultationPlanCopyWithImpl<$Res, $Val extends ConsultationPlan>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String,
-      consultations: null == consultations
+      consultations: freezed == consultations
           ? _value.consultations
           : consultations // ignore: cast_nullable_to_non_nullable
-              as List<Consultation>,
-      materials: null == materials
+              as List<Consultation>?,
+      materials: freezed == materials
           ? _value.materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
+              as List<PlanMaterial>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -233,8 +237,10 @@ abstract class _$$ConsultationPlanImplCopyWith<$Res>
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String consultantProfileId,
-      List<Consultation> consultations,
-      List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Consultation>? consultations,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -269,8 +275,8 @@ class __$$ConsultationPlanImplCopyWithImpl<$Res>
     Object? topics = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = null,
-    Object? consultations = null,
-    Object? materials = null,
+    Object? consultations = freezed,
+    Object? materials = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -331,14 +337,14 @@ class __$$ConsultationPlanImplCopyWithImpl<$Res>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String,
-      consultations: null == consultations
+      consultations: freezed == consultations
           ? _value._consultations
           : consultations // ignore: cast_nullable_to_non_nullable
-              as List<Consultation>,
-      materials: null == materials
+              as List<Consultation>?,
+      materials: freezed == materials
           ? _value._materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
+              as List<PlanMaterial>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -371,8 +377,10 @@ class _$ConsultationPlanImpl implements _ConsultationPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       this.consultantProfile,
       required this.consultantProfileId,
-      required final List<Consultation> consultations,
-      required final List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Consultation>? consultations,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
       required this.createdAt,
       required this.updatedAt})
       : _learningOutcomes = learningOutcomes,
@@ -437,20 +445,26 @@ class _$ConsultationPlanImpl implements _ConsultationPlan {
   final ConsultantProfile? consultantProfile;
   @override
   final String consultantProfileId;
-  final List<Consultation> _consultations;
+  final List<Consultation>? _consultations;
   @override
-  List<Consultation> get consultations {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Consultation>? get consultations {
+    final value = _consultations;
+    if (value == null) return null;
     if (_consultations is EqualUnmodifiableListView) return _consultations;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_consultations);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<PlanMaterial> _materials;
+  final List<PlanMaterial>? _materials;
   @override
-  List<PlanMaterial> get materials {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials {
+    final value = _materials;
+    if (value == null) return null;
     if (_materials is EqualUnmodifiableListView) return _materials;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_materials);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
@@ -559,8 +573,10 @@ abstract class _ConsultationPlan implements ConsultationPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       final ConsultantProfile? consultantProfile,
       required final String consultantProfileId,
-      required final List<Consultation> consultations,
-      required final List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Consultation>? consultations,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$ConsultationPlanImpl;
 
@@ -598,9 +614,11 @@ abstract class _ConsultationPlan implements ConsultationPlan {
   @override
   String get consultantProfileId;
   @override
-  List<Consultation> get consultations;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Consultation>? get consultations;
   @override
-  List<PlanMaterial> get materials;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials;
   @override
   DateTime get createdAt;
   @override

--- a/backend/lib/generated/models/consultation_plan.g.dart
+++ b/backend/lib/generated/models/consultation_plan.g.dart
@@ -24,12 +24,6 @@ _$ConsultationPlanImpl _$$ConsultationPlanImplFromJson(
               .toList() ??
           const <String>[],
       consultantProfileId: json['consultantProfileId'] as String,
-      consultations: (json['consultations'] as List<dynamic>)
-          .map((e) => Consultation.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      materials: (json['materials'] as List<dynamic>)
-          .map((e) => PlanMaterial.fromJson(e as Map<String, dynamic>))
-          .toList(),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
@@ -49,8 +43,6 @@ Map<String, dynamic> _$$ConsultationPlanImplToJson(
       'materialProvided': instance.materialProvided,
       'learningOutcomes': instance.learningOutcomes,
       'consultantProfileId': instance.consultantProfileId,
-      'consultations': instance.consultations,
-      'materials': instance.materials,
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': instance.updatedAt.toIso8601String(),
     };

--- a/backend/lib/generated/models/subscription_plan.dart
+++ b/backend/lib/generated/models/subscription_plan.dart
@@ -53,10 +53,14 @@ class SubscriptionPlan with _$SubscriptionPlan {
     @JsonKey(includeFromJson: false, includeToJson: false)
     ConsultantProfile? consultantProfile,
     required String consultantProfileId,
-    required List<Subscription> subscriptions,
-    required List<SubscriptionContent> subscriptionContents,
-    required List<TrialSession> trialSessions,
-    required List<PlanMaterial> materials,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<Subscription>? subscriptions,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<SubscriptionContent>? subscriptionContents,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<TrialSession>? trialSessions,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<PlanMaterial>? materials,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _SubscriptionPlan;

--- a/backend/lib/generated/models/subscription_plan.freezed.dart
+++ b/backend/lib/generated/models/subscription_plan.freezed.dart
@@ -44,11 +44,15 @@ mixin _$SubscriptionPlan {
   ConsultantProfile? get consultantProfile =>
       throw _privateConstructorUsedError;
   String get consultantProfileId => throw _privateConstructorUsedError;
-  List<Subscription> get subscriptions => throw _privateConstructorUsedError;
-  List<SubscriptionContent> get subscriptionContents =>
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Subscription>? get subscriptions => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<SubscriptionContent>? get subscriptionContents =>
       throw _privateConstructorUsedError;
-  List<TrialSession> get trialSessions => throw _privateConstructorUsedError;
-  List<PlanMaterial> get materials => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<TrialSession>? get trialSessions => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
@@ -92,10 +96,14 @@ abstract class $SubscriptionPlanCopyWith<$Res> {
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String consultantProfileId,
-      List<Subscription> subscriptions,
-      List<SubscriptionContent> subscriptionContents,
-      List<TrialSession> trialSessions,
-      List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Subscription>? subscriptions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<SubscriptionContent>? subscriptionContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<TrialSession>? trialSessions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -138,10 +146,10 @@ class _$SubscriptionPlanCopyWithImpl<$Res, $Val extends SubscriptionPlan>
     Object? freeTrialDurationMinutes = null,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = null,
-    Object? subscriptions = null,
-    Object? subscriptionContents = null,
-    Object? trialSessions = null,
-    Object? materials = null,
+    Object? subscriptions = freezed,
+    Object? subscriptionContents = freezed,
+    Object? trialSessions = freezed,
+    Object? materials = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -230,22 +238,22 @@ class _$SubscriptionPlanCopyWithImpl<$Res, $Val extends SubscriptionPlan>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String,
-      subscriptions: null == subscriptions
+      subscriptions: freezed == subscriptions
           ? _value.subscriptions
           : subscriptions // ignore: cast_nullable_to_non_nullable
-              as List<Subscription>,
-      subscriptionContents: null == subscriptionContents
+              as List<Subscription>?,
+      subscriptionContents: freezed == subscriptionContents
           ? _value.subscriptionContents
           : subscriptionContents // ignore: cast_nullable_to_non_nullable
-              as List<SubscriptionContent>,
-      trialSessions: null == trialSessions
+              as List<SubscriptionContent>?,
+      trialSessions: freezed == trialSessions
           ? _value.trialSessions
           : trialSessions // ignore: cast_nullable_to_non_nullable
-              as List<TrialSession>,
-      materials: null == materials
+              as List<TrialSession>?,
+      materials: freezed == materials
           ? _value.materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
+              as List<PlanMaterial>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -304,10 +312,14 @@ abstract class _$$SubscriptionPlanImplCopyWith<$Res>
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String consultantProfileId,
-      List<Subscription> subscriptions,
-      List<SubscriptionContent> subscriptionContents,
-      List<TrialSession> trialSessions,
-      List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Subscription>? subscriptions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<SubscriptionContent>? subscriptionContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<TrialSession>? trialSessions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -349,10 +361,10 @@ class __$$SubscriptionPlanImplCopyWithImpl<$Res>
     Object? freeTrialDurationMinutes = null,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = null,
-    Object? subscriptions = null,
-    Object? subscriptionContents = null,
-    Object? trialSessions = null,
-    Object? materials = null,
+    Object? subscriptions = freezed,
+    Object? subscriptionContents = freezed,
+    Object? trialSessions = freezed,
+    Object? materials = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -441,22 +453,22 @@ class __$$SubscriptionPlanImplCopyWithImpl<$Res>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String,
-      subscriptions: null == subscriptions
+      subscriptions: freezed == subscriptions
           ? _value._subscriptions
           : subscriptions // ignore: cast_nullable_to_non_nullable
-              as List<Subscription>,
-      subscriptionContents: null == subscriptionContents
+              as List<Subscription>?,
+      subscriptionContents: freezed == subscriptionContents
           ? _value._subscriptionContents
           : subscriptionContents // ignore: cast_nullable_to_non_nullable
-              as List<SubscriptionContent>,
-      trialSessions: null == trialSessions
+              as List<SubscriptionContent>?,
+      trialSessions: freezed == trialSessions
           ? _value._trialSessions
           : trialSessions // ignore: cast_nullable_to_non_nullable
-              as List<TrialSession>,
-      materials: null == materials
+              as List<TrialSession>?,
+      materials: freezed == materials
           ? _value._materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
+              as List<PlanMaterial>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -496,10 +508,14 @@ class _$SubscriptionPlanImpl implements _SubscriptionPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       this.consultantProfile,
       required this.consultantProfileId,
-      required final List<Subscription> subscriptions,
-      required final List<SubscriptionContent> subscriptionContents,
-      required final List<TrialSession> trialSessions,
-      required final List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Subscription>? subscriptions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<SubscriptionContent>? subscriptionContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<TrialSession>? trialSessions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
       required this.createdAt,
       required this.updatedAt})
       : _learningOutcomes = learningOutcomes,
@@ -587,37 +603,49 @@ class _$SubscriptionPlanImpl implements _SubscriptionPlan {
   final ConsultantProfile? consultantProfile;
   @override
   final String consultantProfileId;
-  final List<Subscription> _subscriptions;
+  final List<Subscription>? _subscriptions;
   @override
-  List<Subscription> get subscriptions {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Subscription>? get subscriptions {
+    final value = _subscriptions;
+    if (value == null) return null;
     if (_subscriptions is EqualUnmodifiableListView) return _subscriptions;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_subscriptions);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<SubscriptionContent> _subscriptionContents;
+  final List<SubscriptionContent>? _subscriptionContents;
   @override
-  List<SubscriptionContent> get subscriptionContents {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<SubscriptionContent>? get subscriptionContents {
+    final value = _subscriptionContents;
+    if (value == null) return null;
     if (_subscriptionContents is EqualUnmodifiableListView)
       return _subscriptionContents;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_subscriptionContents);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<TrialSession> _trialSessions;
+  final List<TrialSession>? _trialSessions;
   @override
-  List<TrialSession> get trialSessions {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<TrialSession>? get trialSessions {
+    final value = _trialSessions;
+    if (value == null) return null;
     if (_trialSessions is EqualUnmodifiableListView) return _trialSessions;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_trialSessions);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<PlanMaterial> _materials;
+  final List<PlanMaterial>? _materials;
   @override
-  List<PlanMaterial> get materials {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials {
+    final value = _materials;
+    if (value == null) return null;
     if (_materials is EqualUnmodifiableListView) return _materials;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_materials);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
@@ -762,10 +790,14 @@ abstract class _SubscriptionPlan implements SubscriptionPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       final ConsultantProfile? consultantProfile,
       required final String consultantProfileId,
-      required final List<Subscription> subscriptions,
-      required final List<SubscriptionContent> subscriptionContents,
-      required final List<TrialSession> trialSessions,
-      required final List<PlanMaterial> materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Subscription>? subscriptions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<SubscriptionContent>? subscriptionContents,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<TrialSession>? trialSessions,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$SubscriptionPlanImpl;
 
@@ -817,13 +849,17 @@ abstract class _SubscriptionPlan implements SubscriptionPlan {
   @override
   String get consultantProfileId;
   @override
-  List<Subscription> get subscriptions;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Subscription>? get subscriptions;
   @override
-  List<SubscriptionContent> get subscriptionContents;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<SubscriptionContent>? get subscriptionContents;
   @override
-  List<TrialSession> get trialSessions;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<TrialSession>? get trialSessions;
   @override
-  List<PlanMaterial> get materials;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials;
   @override
   DateTime get createdAt;
   @override

--- a/backend/lib/generated/models/subscription_plan.g.dart
+++ b/backend/lib/generated/models/subscription_plan.g.dart
@@ -35,18 +35,6 @@ _$SubscriptionPlanImpl _$$SubscriptionPlanImplFromJson(
       freeTrialDurationMinutes:
           (json['freeTrialDurationMinutes'] as num?)?.toInt() ?? 30,
       consultantProfileId: json['consultantProfileId'] as String,
-      subscriptions: (json['subscriptions'] as List<dynamic>)
-          .map((e) => Subscription.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      subscriptionContents: (json['subscriptionContents'] as List<dynamic>)
-          .map((e) => SubscriptionContent.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      trialSessions: (json['trialSessions'] as List<dynamic>)
-          .map((e) => TrialSession.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      materials: (json['materials'] as List<dynamic>)
-          .map((e) => PlanMaterial.fromJson(e as Map<String, dynamic>))
-          .toList(),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
@@ -73,10 +61,6 @@ Map<String, dynamic> _$$SubscriptionPlanImplToJson(
       'freeTrialEnabled': instance.freeTrialEnabled,
       'freeTrialDurationMinutes': instance.freeTrialDurationMinutes,
       'consultantProfileId': instance.consultantProfileId,
-      'subscriptions': instance.subscriptions,
-      'subscriptionContents': instance.subscriptionContents,
-      'trialSessions': instance.trialSessions,
-      'materials': instance.materials,
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': instance.updatedAt.toIso8601String(),
     };

--- a/backend/lib/generated/models/webinar_plan.dart
+++ b/backend/lib/generated/models/webinar_plan.dart
@@ -47,9 +47,12 @@ class WebinarPlan with _$WebinarPlan {
     @JsonKey(includeFromJson: false, includeToJson: false)
     ConsultantProfile? consultantProfile,
     String? consultantProfileId,
-    required List<Webinar> webinars,
-    required List<PlanMaterial> materials,
-    required List<WebinarCollaborator> collaborators,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<Webinar>? webinars,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<PlanMaterial>? materials,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    List<WebinarCollaborator>? collaborators,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _WebinarPlan;

--- a/backend/lib/generated/models/webinar_plan.freezed.dart
+++ b/backend/lib/generated/models/webinar_plan.freezed.dart
@@ -43,9 +43,12 @@ mixin _$WebinarPlan {
   ConsultantProfile? get consultantProfile =>
       throw _privateConstructorUsedError;
   String? get consultantProfileId => throw _privateConstructorUsedError;
-  List<Webinar> get webinars => throw _privateConstructorUsedError;
-  List<PlanMaterial> get materials => throw _privateConstructorUsedError;
-  List<WebinarCollaborator> get collaborators =>
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Webinar>? get webinars => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<WebinarCollaborator>? get collaborators =>
       throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
@@ -88,9 +91,12 @@ abstract class $WebinarPlanCopyWith<$Res> {
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String? consultantProfileId,
-      List<Webinar> webinars,
-      List<PlanMaterial> materials,
-      List<WebinarCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Webinar>? webinars,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<WebinarCollaborator>? collaborators,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -131,9 +137,9 @@ class _$WebinarPlanCopyWithImpl<$Res, $Val extends WebinarPlan>
     Object? imageUrl = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = freezed,
-    Object? webinars = null,
-    Object? materials = null,
-    Object? collaborators = null,
+    Object? webinars = freezed,
+    Object? materials = freezed,
+    Object? collaborators = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -214,18 +220,18 @@ class _$WebinarPlanCopyWithImpl<$Res, $Val extends WebinarPlan>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String?,
-      webinars: null == webinars
+      webinars: freezed == webinars
           ? _value.webinars
           : webinars // ignore: cast_nullable_to_non_nullable
-              as List<Webinar>,
-      materials: null == materials
+              as List<Webinar>?,
+      materials: freezed == materials
           ? _value.materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
-      collaborators: null == collaborators
+              as List<PlanMaterial>?,
+      collaborators: freezed == collaborators
           ? _value.collaborators
           : collaborators // ignore: cast_nullable_to_non_nullable
-              as List<WebinarCollaborator>,
+              as List<WebinarCollaborator>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -282,9 +288,12 @@ abstract class _$$WebinarPlanImplCopyWith<$Res>
       @JsonKey(includeFromJson: false, includeToJson: false)
       ConsultantProfile? consultantProfile,
       String? consultantProfileId,
-      List<Webinar> webinars,
-      List<PlanMaterial> materials,
-      List<WebinarCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<Webinar>? webinars,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      List<WebinarCollaborator>? collaborators,
       DateTime createdAt,
       DateTime updatedAt});
 
@@ -324,9 +333,9 @@ class __$$WebinarPlanImplCopyWithImpl<$Res>
     Object? imageUrl = freezed,
     Object? consultantProfile = freezed,
     Object? consultantProfileId = freezed,
-    Object? webinars = null,
-    Object? materials = null,
-    Object? collaborators = null,
+    Object? webinars = freezed,
+    Object? materials = freezed,
+    Object? collaborators = freezed,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -407,18 +416,18 @@ class __$$WebinarPlanImplCopyWithImpl<$Res>
           ? _value.consultantProfileId
           : consultantProfileId // ignore: cast_nullable_to_non_nullable
               as String?,
-      webinars: null == webinars
+      webinars: freezed == webinars
           ? _value._webinars
           : webinars // ignore: cast_nullable_to_non_nullable
-              as List<Webinar>,
-      materials: null == materials
+              as List<Webinar>?,
+      materials: freezed == materials
           ? _value._materials
           : materials // ignore: cast_nullable_to_non_nullable
-              as List<PlanMaterial>,
-      collaborators: null == collaborators
+              as List<PlanMaterial>?,
+      collaborators: freezed == collaborators
           ? _value._collaborators
           : collaborators // ignore: cast_nullable_to_non_nullable
-              as List<WebinarCollaborator>,
+              as List<WebinarCollaborator>?,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -456,9 +465,12 @@ class _$WebinarPlanImpl implements _WebinarPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       this.consultantProfile,
       this.consultantProfileId,
-      required final List<Webinar> webinars,
-      required final List<PlanMaterial> materials,
-      required final List<WebinarCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Webinar>? webinars,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<WebinarCollaborator>? collaborators,
       required this.createdAt,
       required this.updatedAt})
       : _topics = topics,
@@ -538,28 +550,37 @@ class _$WebinarPlanImpl implements _WebinarPlan {
   final ConsultantProfile? consultantProfile;
   @override
   final String? consultantProfileId;
-  final List<Webinar> _webinars;
+  final List<Webinar>? _webinars;
   @override
-  List<Webinar> get webinars {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Webinar>? get webinars {
+    final value = _webinars;
+    if (value == null) return null;
     if (_webinars is EqualUnmodifiableListView) return _webinars;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_webinars);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<PlanMaterial> _materials;
+  final List<PlanMaterial>? _materials;
   @override
-  List<PlanMaterial> get materials {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials {
+    final value = _materials;
+    if (value == null) return null;
     if (_materials is EqualUnmodifiableListView) return _materials;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_materials);
+    return EqualUnmodifiableListView(value);
   }
 
-  final List<WebinarCollaborator> _collaborators;
+  final List<WebinarCollaborator>? _collaborators;
   @override
-  List<WebinarCollaborator> get collaborators {
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<WebinarCollaborator>? get collaborators {
+    final value = _collaborators;
+    if (value == null) return null;
     if (_collaborators is EqualUnmodifiableListView) return _collaborators;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_collaborators);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
@@ -690,9 +711,12 @@ abstract class _WebinarPlan implements WebinarPlan {
       @JsonKey(includeFromJson: false, includeToJson: false)
       final ConsultantProfile? consultantProfile,
       final String? consultantProfileId,
-      required final List<Webinar> webinars,
-      required final List<PlanMaterial> materials,
-      required final List<WebinarCollaborator> collaborators,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<Webinar>? webinars,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<PlanMaterial>? materials,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final List<WebinarCollaborator>? collaborators,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$WebinarPlanImpl;
 
@@ -740,11 +764,14 @@ abstract class _WebinarPlan implements WebinarPlan {
   @override
   String? get consultantProfileId;
   @override
-  List<Webinar> get webinars;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<Webinar>? get webinars;
   @override
-  List<PlanMaterial> get materials;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<PlanMaterial>? get materials;
   @override
-  List<WebinarCollaborator> get collaborators;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  List<WebinarCollaborator>? get collaborators;
   @override
   DateTime get createdAt;
   @override

--- a/backend/lib/generated/models/webinar_plan.g.dart
+++ b/backend/lib/generated/models/webinar_plan.g.dart
@@ -31,15 +31,6 @@ _$WebinarPlanImpl _$$WebinarPlanImplFromJson(Map<String, dynamic> json) =>
           const <String>[],
       imageUrl: json['imageUrl'] as String?,
       consultantProfileId: json['consultantProfileId'] as String?,
-      webinars: (json['webinars'] as List<dynamic>)
-          .map((e) => Webinar.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      materials: (json['materials'] as List<dynamic>)
-          .map((e) => PlanMaterial.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      collaborators: (json['collaborators'] as List<dynamic>)
-          .map((e) => WebinarCollaborator.fromJson(e as Map<String, dynamic>))
-          .toList(),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
@@ -64,9 +55,6 @@ Map<String, dynamic> _$$WebinarPlanImplToJson(_$WebinarPlanImpl instance) =>
       'learningOutcomes': instance.learningOutcomes,
       'imageUrl': instance.imageUrl,
       'consultantProfileId': instance.consultantProfileId,
-      'webinars': instance.webinars,
-      'materials': instance.materials,
-      'collaborators': instance.collaborators,
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': instance.updatedAt.toIso8601String(),
     };

--- a/backend/lib/services/auth/auth_service.dart
+++ b/backend/lib/services/auth/auth_service.dart
@@ -1,4 +1,5 @@
 import 'package:backend/database/database_client.dart';
+import 'package:prisma_flutter_connector/runtime_server.dart';
 import 'package:backend/services/auth/github_oauth_service.dart';
 import 'package:backend/services/auth/google_token_verifier.dart';
 import 'package:backend/services/auth/jwt_service.dart';
@@ -147,12 +148,22 @@ class AuthService {
         txn: txn,
       );
 
-      // Create consultee profile
+      // Create consultee profile and link to user
+      final consulteeProfileId = _uuid.v4();
       await _db.createConsulteeProfile(
-        id: _uuid.v4(),
+        id: consulteeProfileId,
         userId: userId,
         executor: txn,
       );
+
+      // Update user with consulteeProfileId FK
+      final updateQuery = JsonQueryBuilder()
+          .model('users')
+          .action(QueryAction.update)
+          .where({'id': userId})
+          .data({'consulteeProfileId': consulteeProfileId, 'updatedAt': DateTime.now().toUtc().toIso8601String()})
+          .build();
+      await txn.executeMutation(updateQuery);
 
       // Create default preferences (matches web BetterAuth databaseHooks)
       await _db.users.createDefaultPreferences(userId, txn: txn);

--- a/backend/pubspec.yaml
+++ b/backend/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   json_annotation: ^4.9.0
   logging: ^1.3.0
   postgres: ^3.4.5
-  prisma_flutter_connector: ^0.4.0
+  prisma_flutter_connector: ^0.5.0
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/lib/features/notifications/screens/notifications_screen.dart
+++ b/lib/features/notifications/screens/notifications_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder notifications screen.
+///
+/// Will be replaced with full implementation when Novu notification
+/// system is integrated (see GitHub issue #32).
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notifications')),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.notifications_none, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text(
+              'No notifications yet',
+              style: TextStyle(fontSize: 18, color: Colors.grey),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'You\'ll see updates about your sessions here',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../notifications/screens/notifications_screen.dart';
+
 import '../../auth/providers/auth_provider.dart';
 import '../providers/delete_account_provider.dart';
 
@@ -84,9 +86,10 @@ class ProfileScreen extends ConsumerWidget {
               icon: Icons.notifications_outlined,
               title: 'Notifications',
               onTap: () {
-                // TODO: Navigate to notifications settings
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Coming soon')),
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const NotificationsScreen(),
+                  ),
                 );
               },
             ),


### PR DESCRIPTION
## Summary

Fixes the 3 remaining E2E bugs. The other 5 (#86, #87, #92, #97, #99) were already fixed in previous PRs and have been closed.

### Bug Fixes

**#103 — Signup doesn't set consulteeProfileId**
- `auth_service.dart`: After creating ConsulteeProfile, now updates the user record with `consulteeProfileId` FK
- Previously the profile existed but the user had no reference to it, breaking trial/booking flows

**#102 — Plan delete/fetch null cast to List**
- Made relation List fields nullable (`@JsonKey(includeFromJson: false)`) in all 4 plan models: SubscriptionPlan, ConsultationPlan, WebinarPlan, ClassPlan
- These relation fields (subscriptions, materials, collaborators, etc.) are only populated when `include()` is used; without includes, `fromJson` was throwing null-to-List cast errors

**#101 — Notifications button does nothing**
- Created `NotificationsScreen` placeholder at `lib/features/notifications/screens/`
- Updated profile screen to navigate to it instead of showing "Coming soon" snackbar

### Also
- Bumped `prisma_flutter_connector` to `^0.5.0` (code_builder generators, JSON deser fix)

## Test plan
- [x] `dart analyze` — zero errors on both backend and frontend
- [x] Freezed build_runner regeneration passes
- [ ] POST /api/auth/signup — verify consulteeProfileId is set on user
- [ ] DELETE /api/plans/subscriptions/:id — verify no null cast error
- [ ] Tap notifications button on profile screen — verify navigation works

Closes #101, #102, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)