### PR TITLE
fix: bugfix and refactor Windows start script

### DIFF
--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -1,22 +1,79 @@
 <#
 .SYNOPSIS
-Starts the Familiarise application on Windows.
+Starts the Familiarise application on Windows (full rebuild).
+
+.DESCRIPTION
+Mirrors scripts/start-android.sh for Windows/PowerShell:
+  1. Frees port 8080
+  2. Cleans + rebuilds Flutter and regenerates code
+  3. Builds and starts the Dart Frog backend
+  4. Ensures an Android device/emulator is available, sets up adb reverse
+  5. Runs the Flutter app on the target device
+
+.PARAMETER Port
+Backend port (default 8080).
+
+.PARAMETER Avd
+Android Virtual Device name to launch when no device is connected (default Pixel_10).
+
+.EXAMPLE
+.\scripts\start-windows.ps1 -Avd Pixel_7_API_34
 #>
+param(
+    [int]$Port = 8080,
+    [string]$Avd = "Pixel_10"
+)
 
 $ErrorActionPreference = "Stop"
 
-# Get the script directory and navigate to the project root
+# Resolve project root from the script location and move there.
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location "$scriptDir\.."
+$projectRoot = Resolve-Path "$scriptDir\.."
+Set-Location $projectRoot
 
-Write-Host "=== Killing processes on port 8080 ===" -ForegroundColor Cyan
-$port8080Pids = (Get-NetTCPConnection -LocalPort 8080 -ErrorAction SilentlyContinue).OwningProcess
-if ($port8080Pids) {
-    foreach ($pidToKill in $port8080Pids) {
-        Stop-Process -Id $pidToKill -Force -ErrorAction SilentlyContinue
-        Write-Host "Killed process $pidToKill on port 8080"
-    }
+# Android SDK tool locations.
+$sdkRoot     = Join-Path $env:LOCALAPPDATA "Android\Sdk"
+$adbExe      = Join-Path $sdkRoot "platform-tools\adb.exe"
+$emulatorExe = Join-Path $sdkRoot "emulator\emulator.exe"
+
+# --- Helpers -----------------------------------------------------------------
+
+# Returns the id of the first fully-booted ("device" state) Android device,
+# or $null if none are attached. Skips the "List of devices attached" header.
+function Get-ConnectedAndroidDevice {
+    if (-not (Test-Path $adbExe)) { return $null }
+    $line = & $adbExe devices |
+        Select-Object -Skip 1 |
+        Where-Object { $_ -match '\bdevice$' } |
+        Select-Object -First 1
+    if ($line) { return ($line -split '\s+')[0] }
+    return $null
 }
+
+# Blocks until $Port accepts a TCP connection or the timeout elapses.
+function Wait-ForPort {
+    param([int]$PortNumber, [int]$TimeoutSeconds = 30)
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-NetConnection -ComputerName "localhost" -Port $PortNumber -WarningAction SilentlyContinue -InformationLevel Quiet) {
+            return $true
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+# --- Free the backend port ---------------------------------------------------
+
+Write-Host "=== Killing processes on port $Port ===" -ForegroundColor Cyan
+$portPids = (Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue).OwningProcess |
+    Sort-Object -Unique
+foreach ($pidToKill in $portPids) {
+    Stop-Process -Id $pidToKill -Force -ErrorAction SilentlyContinue
+    Write-Host "Killed process $pidToKill on port $Port"
+}
+
+# --- Flutter clean + codegen -------------------------------------------------
 
 Write-Host "=== Cleaning Flutter build ===" -ForegroundColor Cyan
 flutter clean
@@ -27,77 +84,85 @@ flutter pub get
 Write-Host "=== Regenerating code ===" -ForegroundColor Cyan
 dart run build_runner build --delete-conflicting-outputs
 
+# --- Backend build -----------------------------------------------------------
+
 Write-Host "=== Building backend ===" -ForegroundColor Cyan
-Set-Location backend
+Push-Location backend
+try {
+    if (-not (Test-Path ".env")) {
+        Write-Host "WARNING: backend/.env not found! Copying .env.example to .env..." -ForegroundColor Yellow
+        Copy-Item ".env.example" ".env"
+        Write-Host "Please make sure to fill in your database credentials in backend/.env if needed." -ForegroundColor Yellow
+    }
 
-if (-not (Test-Path ".env")) {
-    Write-Host "WARNING: backend/.env not found! Copying .env.example to .env..." -ForegroundColor Yellow
-    Copy-Item ".env.example" ".env"
-    Write-Host "Please make sure to fill in your database credentials in backend/.env if needed." -ForegroundColor Yellow
+    dart pub get
+    dart pub global run dart_frog_cli:dart_frog build
+
+    Write-Host "=== Starting backend server ===" -ForegroundColor Cyan
+    # Set PORT for the child process (inherited from this session), then restore
+    # it so the variable doesn't leak. Avoids Start-Process -Environment, which
+    # requires PowerShell 7.4+ (Windows ships 5.1 by default).
+    $prevPort = $env:PORT
+    $env:PORT = "$Port"
+    try {
+        $serverProc = Start-Process dart `
+            -ArgumentList "build/bin/server.dart" `
+            -NoNewWindow -PassThru
+    }
+    finally {
+        $env:PORT = $prevPort
+    }
+    Write-Host "Backend server started (PID $($serverProc.Id))"
 }
-
-dart pub global run dart_frog_cli:dart_frog build
-
-Write-Host "=== Starting backend server ===" -ForegroundColor Cyan
-$env:PORT = "8080"
-Start-Process dart -ArgumentList "build/bin/server.dart" -NoNewWindow
-Set-Location ..
+finally {
+    Pop-Location
+}
 
 Write-Host "=== Waiting for backend to start ===" -ForegroundColor Cyan
-Start-Sleep -Seconds 3
-
-$adbExe = "$env:LOCALAPPDATA\Android\Sdk\platform-tools\adb.exe"
-$deviceConnected = $false
-
-if (Test-Path $adbExe) {
-    $devices = & $adbExe devices
-    $connectedDevices = $devices | Where-Object { $_ -match '\bdevice$' }
-    if ($connectedDevices) {
-        $deviceConnected = $true
-        Write-Host "=== Device already connected ===" -ForegroundColor Green
-        Write-Host "Skipping emulator launch."
-    }
+if (-not (Wait-ForPort -PortNumber $Port)) {
+    Write-Host "Backend did not start listening on port $Port in time." -ForegroundColor Red
+    exit 1
 }
+Write-Host "Backend is up on port $Port." -ForegroundColor Green
 
-if (-not $deviceConnected) {
+# --- Ensure an Android device is available -----------------------------------
+
+$targetDevice = Get-ConnectedAndroidDevice
+
+if ($targetDevice) {
+    Write-Host "=== Device already connected ($targetDevice) ===" -ForegroundColor Green
+    Write-Host "Skipping emulator launch."
+} else {
     Write-Host "=== Starting Android emulator ===" -ForegroundColor Cyan
-    $emulatorExe = "$env:LOCALAPPDATA\Android\Sdk\emulator\emulator.exe"
     if (Test-Path $emulatorExe) {
-        # You can change Pixel_10 to whatever your emulator AVD name is
-        Write-Host "Starting Pixel_10 emulator..."
-        Start-Process $emulatorExe -ArgumentList "-avd Pixel_10" -NoNewWindow
-        
+        Write-Host "Starting $Avd emulator..."
+        Start-Process $emulatorExe -ArgumentList "-avd", $Avd -NoNewWindow
+
         Write-Host "=== Waiting for emulator to boot ===" -ForegroundColor Cyan
         if (Test-Path $adbExe) {
             & $adbExe wait-for-device
             Start-Sleep -Seconds 5
+            $targetDevice = Get-ConnectedAndroidDevice
         }
     } else {
         Write-Host "Could not find emulator at $emulatorExe. Please ensure an emulator is running." -ForegroundColor Yellow
     }
 }
 
-if (Test-Path $adbExe) {
-    Write-Host "=== Setting up port forwarding ===" -ForegroundColor Cyan
-    & $adbExe reverse tcp:8080 tcp:8080
-} else {
-    Write-Host "Could not find adb at $adbExe. Skipping port forwarding." -ForegroundColor Yellow
-}
-
-Write-Host "=== Running Flutter app ===" -ForegroundColor Cyan
-
-# Try to find a connected physical Android device ID
-$targetDevice = $null
-if (Test-Path $adbExe) {
-    $adbDevices = & $adbExe devices | Select-Object -Skip 1
-    $physicalDevice = $adbDevices | Where-Object { $_ -match '\bdevice$' } | Select-Object -First 1
-    if ($physicalDevice) {
-        $targetDevice = ($physicalDevice -split '\s+')[0]
-        Write-Host "Targeting device: $targetDevice" -ForegroundColor Green
-    }
-}
+# --- Port forwarding ---------------------------------------------------------
 
 if ($targetDevice) {
+    Write-Host "=== Setting up port forwarding ===" -ForegroundColor Cyan
+    & $adbExe -s $targetDevice reverse "tcp:$Port" "tcp:$Port"
+} else {
+    Write-Host "No Android device detected. Skipping port forwarding." -ForegroundColor Yellow
+}
+
+# --- Run the app -------------------------------------------------------------
+
+Write-Host "=== Running Flutter app ===" -ForegroundColor Cyan
+if ($targetDevice) {
+    Write-Host "Targeting device: $targetDevice" -ForegroundColor Green
     flutter run -d $targetDevice
 } else {
     flutter run


### PR DESCRIPTION
## Summary

Review + bugfix + refactor pass over `scripts/start-windows.ps1` (added in the recent Windows-support commits). The script now matches the behavior of `scripts/start-android.sh` more closely and is robust on a fresh Windows checkout.

## Bugs fixed

- **Fresh-checkout backend failure** — added `dart pub get` in `backend/` before `dart_frog build`; backend deps were never resolved before, so a clean checkout failed.
- **Backend startup race** — replaced the fixed `Start-Sleep -Seconds 3` with `Wait-ForPort` polling, and the script now exits with an error if the backend never starts listening (instead of launching the app against a dead backend).
- **`adb reverse` with multiple devices** — now targets the specific device via `-s <device>`; previously ambiguous/failing when an emulator and a phone were both attached.
- **`$env:PORT` session leak** — now scoped to the child process and restored afterward.

## Refactor / cleanup

- Collapsed the **duplicated device-detection logic** into a single `Get-ConnectedAndroidDevice` helper.
- Hoisted magic values into a `param()` block: `-Port` (default 8080) and `-Avd` (default `Pixel_10`), plus SDK path variables, with a doc comment and usage example.
- Wrapped the backend build in `Push-Location`/`Pop-Location` with `try/finally` so a build failure can't strand the shell in `backend/`.

## Compatibility

Deliberately avoided `Start-Process -Environment` (PowerShell 7.4+ only) since Windows ships PowerShell 5.1 by default — the script stays 5.1-compatible.

## Testing

- `pwsh` is not available in the dev environment, so the script was reviewed by hand rather than executed. Recommend a manual run on a Windows machine before merge.

## Follow-up (not in this PR)

There is no Windows port of `scripts/regenerate-build.sh` (Prisma client + backend codegen). This script, like `start-android.sh`, assumes that generated code already exists. A `regenerate-build.ps1` could be added separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)